### PR TITLE
Add implementations for curry out to 15 arguments

### DIFF
--- a/Curry.xcodeproj/project.pbxproj
+++ b/Curry.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		F88630761B4EF9B200F53969 /* Curry.h in Headers */ = {isa = PBXBuildFile; fileRef = F88630741B4EF9B200F53969 /* Curry.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F88630961B4EFA2700F53969 /* Curry.h in Headers */ = {isa = PBXBuildFile; fileRef = F88630741B4EF9B200F53969 /* Curry.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F886309A1B4EFD7600F53969 /* Curry.swift in Sources */ = {isa = PBXBuildFile; fileRef = F88630991B4EFD7600F53969 /* Curry.swift */; };
+		F886309B1B4EFD7600F53969 /* Curry.swift in Sources */ = {isa = PBXBuildFile; fileRef = F88630991B4EFD7600F53969 /* Curry.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -16,6 +18,7 @@
 		F88630741B4EF9B200F53969 /* Curry.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Curry.h; sourceTree = "<group>"; };
 		F88630751B4EF9B200F53969 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		F886307D1B4EF9F800F53969 /* Curry.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Curry.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		F88630991B4EFD7600F53969 /* Curry.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Curry.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -56,6 +59,7 @@
 		F88630721B4EF9B200F53969 /* Source */ = {
 			isa = PBXGroup;
 			children = (
+				F88630991B4EFD7600F53969 /* Curry.swift */,
 				F88630731B4EF9B200F53969 /* Resources */,
 			);
 			path = Source;
@@ -185,6 +189,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F886309A1B4EFD7600F53969 /* Curry.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -192,6 +197,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F886309B1B4EFD7600F53969 /* Curry.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Curry.xcodeproj/xcshareddata/xcschemes/Curry-Mac.xcscheme
+++ b/Curry.xcodeproj/xcshareddata/xcschemes/Curry-Mac.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "F886307C1B4EF9F800F53969"
-               BuildableName = "Curry-Mac.framework"
+               BuildableName = "Curry.framework"
                BlueprintName = "Curry-Mac"
                ReferencedContainer = "container:Curry.xcodeproj">
             </BuildableReference>
@@ -43,7 +43,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "F886307C1B4EF9F800F53969"
-            BuildableName = "Curry-Mac.framework"
+            BuildableName = "Curry.framework"
             BlueprintName = "Curry-Mac"
             ReferencedContainer = "container:Curry.xcodeproj">
          </BuildableReference>
@@ -61,7 +61,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "F886307C1B4EF9F800F53969"
-            BuildableName = "Curry-Mac.framework"
+            BuildableName = "Curry.framework"
             BlueprintName = "Curry-Mac"
             ReferencedContainer = "container:Curry.xcodeproj">
          </BuildableReference>

--- a/Curry.xcodeproj/xcshareddata/xcschemes/Curry-iOS.xcscheme
+++ b/Curry.xcodeproj/xcshareddata/xcschemes/Curry-iOS.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "F88630551B4EF96200F53969"
-               BuildableName = "Curry-iOS.framework"
+               BuildableName = "Curry.framework"
                BlueprintName = "Curry-iOS"
                ReferencedContainer = "container:Curry.xcodeproj">
             </BuildableReference>
@@ -43,7 +43,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "F88630551B4EF96200F53969"
-            BuildableName = "Curry-iOS.framework"
+            BuildableName = "Curry.framework"
             BlueprintName = "Curry-iOS"
             ReferencedContainer = "container:Curry.xcodeproj">
          </BuildableReference>
@@ -61,7 +61,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "F88630551B4EF96200F53969"
-            BuildableName = "Curry-iOS.framework"
+            BuildableName = "Curry.framework"
             BlueprintName = "Curry-iOS"
             ReferencedContainer = "container:Curry.xcodeproj">
          </BuildableReference>

--- a/Source/Curry.swift
+++ b/Source/Curry.swift
@@ -1,0 +1,101 @@
+public func curry<A, B, C>(function: (A, B) -> C) -> A -> B -> C {
+    return { a in { b in function(a, b) } }
+}
+
+public func curry<A, B, C, D>(function: (A, B, C) -> D) -> A -> B -> C -> D {
+    return { a in { b in { c in function(a, b, c) } } }
+}
+
+public func curry<A, B, C, D, E>(function: (A, B, C, D) -> E) -> A -> B -> C -> D -> E {
+    return { a in { b in { c in { d in function(a, b, c, d) } } } }
+}
+
+public func curry<A, B, C, D, E, F>(function: (A, B, C, D, E) -> F) -> A -> B -> C -> D -> E -> F {
+    return { a in { b in { c in { d in { e in function(a, b, c, d, e) } } } } }
+}
+
+public func curry<A, B, C, D, E, F, G>(function: (A, B, C, D, E, F) -> G) -> A -> B -> C -> D -> E -> F -> G {
+    return { a in { b in { c in { d in { e in { f in function(a, b, c, d, e, f) } } } } } }
+}
+
+public func curry<A, B, C, D, E, F, G, H>(function: (A, B, C, D, E, F, G) -> H) -> A -> B -> C -> D -> E -> F -> G -> H {
+    return { a in { b in { c in { d in { e in { f in { g in function(a, b, c, d, e, f, g) } } } } } } }
+}
+
+public func curry<A, B, C, D, E, F, G, H, I>(function: (A, B, C, D, E, F, G, H) -> I) -> A -> B -> C -> D -> E -> F -> G -> H -> I {
+    return { a in { b in { c in { d in { e in { f in { g in { h in function(a, b, c, d, e, f, g, h) } } } } } } } }
+}
+
+public func curry<A, B, C, D, E, F, G, H, I, J>(function: (A, B, C, D, E, F, G, H, I) -> J) -> A -> B -> C -> D -> E -> F -> G -> H -> I -> J {
+    return { a in { b in { c in { d in { e in { f in { g in { h in { i in function(a, b, c, d, e, f, g, h, i) } } } } } } } } }
+}
+
+public func curry<A, B, C, D, E, F, G, H, I, J, K>(function: (A, B, C, D, E, F, G, H, I, J) -> K) -> A -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K {
+    return { a in { b in { c in { d in { e in { f in { g in { h in { i in { j in function(a, b, c, d, e, f, g, h, i, j) } } } } } } } } } }
+}
+
+public func curry<A, B, C, D, E, F, G, H, I, J, K, L>(function: (A, B, C, D, E, F, G, H, I, J, K) -> L) -> A -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L {
+    return { a in { b in { c in { d in { e in { f in { g in { h in { i in { j in { k in function(a, b, c, d, e, f, g, h, i, j, k) } } } } } } } } } } }
+}
+
+public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M>(function: (A, B, C, D, E, F, G, H, I, J, K, L) -> M) -> A -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M {
+    return { a in { b in { c in { d in { e in { f in { g in { h in { i in { j in { k in { l in function(a, b, c, d, e, f, g, h, i, j, k, l) } } } } } } } } } } } }
+}
+
+public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N>(function: (A, B, C, D, E, F, G, H, I, J, K, L, M) -> N) -> A -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N {
+    return { a in { b in { c in { d in { e in { f in { g in { h in { i in { j in { k in { l in { m in function(a, b, c, d, e, f, g, h, i, j, k, l, m) } } } } } } } } } } } } }
+}
+
+public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O>(function: (A, B, C, D, E, F, G, H, I, J, K, L, M, N) -> O) -> A -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O {
+    return { a in { b in { c in { d in { e in { f in { g in { h in { i in { j in { k in { l in { m in { n in function(a, b, c, d, e, f, g, h, i, j, k, l, m, n) } } } } } } } } } } } } } }
+}
+
+public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P>(function: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O) -> P) -> A -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O -> P {
+    return { a in { b in { c in { d in { e in { f in { g in { h in { i in { j in { k in { l in { m in { n in { o in function(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o) } } } } } } } } } } } } } } }
+}
+
+// Compile times become exponential past this point
+
+//public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q>(function: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P) -> Q) -> A -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O -> P -> Q {
+//    return { a in { b in { c in { d in { e in { f in { g in { h in { i in { j in { k in { l in { m in { n in { o in { p in function(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p) } } } } } } } } } } } } } } } }
+//}
+
+//public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R>(function: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q) -> R) -> A -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O -> P -> Q -> R {
+//    return { a in { b in { c in { d in { e in { f in { g in { h in { i in { j in { k in { l in { m in { n in { o in { p in { q in function(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q) } } } } } } } } } } } } } } } } }
+//}
+
+//public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S>(function: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R) -> S) -> A -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O -> P -> Q -> R -> S {
+//    return { a in { b in { c in { d in { e in { f in { g in { h in { i in { j in { k in { l in { m in { n in { o in { p in { q in { r in function(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r) } } } } } } } } } } } } } } } } } }
+//}
+
+//public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T>(function: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S) -> T) -> A -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O -> P -> Q -> R -> S -> T {
+//    return { a in { b in { c in { d in { e in { f in { g in { h in { i in { j in { k in { l in { m in { n in { o in { p in { q in { r in { s in function(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s) } } } } } } } } } } } } } } } } } } }
+//}
+
+//public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U>(function: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T) -> U) -> A -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O -> P -> Q -> R -> S -> T -> U {
+//    return { a in { b in { c in { d in { e in { f in { g in { h in { i in { j in { k in { l in { m in { n in { o in { p in { q in { r in { s in { t in function(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t) } } } } } } } } } } } } } } } } } } } }
+//}
+
+//public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V>(function: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U) -> V) -> A -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O -> P -> Q -> R -> S -> T -> U -> V {
+//    return { a in { b in { c in { d in { e in { f in { g in { h in { i in { j in { k in { l in { m in { n in { o in { p in { q in { r in { s in { t in { u in function(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u) } } } } } } } } } } } } } } } } } } } } }
+//}
+
+//public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W>(function: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V) -> W) -> A -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O -> P -> Q -> R -> S -> T -> U -> V -> W {
+//    return { a in { b in { c in { d in { e in { f in { g in { h in { i in { j in { k in { l in { m in { n in { o in { p in { q in { r in { s in { t in { u in { v in function(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v) } } } } } } } } } } } } } } } } } } } } } }
+//}
+
+//public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X>(function: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W) -> X) -> A -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O -> P -> Q -> R -> S -> T -> U -> V -> W -> X {
+//    return { a in { b in { c in { d in { e in { f in { g in { h in { i in { j in { k in { l in { m in { n in { o in { p in { q in { r in { s in { t in { u in { v in { w in function(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w) } } } } } } } } } } } } } } } } } } } } } } }
+//}
+
+//public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y>(function: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X) -> Y) -> A -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O -> P -> Q -> R -> S -> T -> U -> V -> W -> X -> Y {
+//    return { a in { b in { c in { d in { e in { f in { g in { h in { i in { j in { k in { l in { m in { n in { o in { p in { q in { r in { s in { t in { u in { v in { w in { x in function(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x) } } } } } } } } } } } } } } } } } } } } } } } }
+//}
+
+//public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z>(function: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y) -> Z) -> A -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O -> P -> Q -> R -> S -> T -> U -> V -> W -> X -> Y -> Z {
+//    return { a in { b in { c in { d in { e in { f in { g in { h in { i in { j in { k in { l in { m in { n in { o in { p in { q in { r in { s in { t in { u in { v in { w in { x in { y in function(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y) } } } } } } } } } } } } } } } } } } } } } } } } }
+//}
+
+//public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AA>(function: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z) -> AA) -> A -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O -> P -> Q -> R -> S -> T -> U -> V -> W -> X -> Y -> Z -> AA {
+//    return { a in { b in { c in { d in { e in { f in { g in { h in { i in { j in { k in { l in { m in { n in { o in { p in { q in { r in { s in { t in { u in { v in { w in { x in { y in { z in function(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z) } } } } } } } } } } } } } } } } } } } } } } } } } }
+//}

--- a/Source/Resources/Curry.h
+++ b/Source/Resources/Curry.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2015 thoughtbot. All rights reserved.
 //
 
-#import <Foundation/Foundation>
+#import <Foundation/Foundation.h>
 
 //! Project version number for Curry.
 FOUNDATION_EXPORT double CurryVersionNumber;


### PR DESCRIPTION
This adds `curry` out to 15 arguments. There are implementations for up
to 26 arguments, but compile times become exponential past 15 arguments
(15 arguments takes 2 seconds on my machine, 18 arguments takes 10
seconds.)
