### PR TITLE
MOAR CURRY!!

### DIFF
--- a/Source/Curry.swift
+++ b/Source/Curry.swift
@@ -58,7 +58,7 @@ public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P>(function: (A, 
     return { a in { b in { c in { d in { e in { f in { g in { h in { i in { j in { k in { l in { m in { n in { o in function(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o) } } } } } } } } } } } } } } }
 }
 
-// Compile times become exponential past this point
+// Compile time become exponential past this point
 
 //public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q>(function: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P) -> Q) -> A -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O -> P -> Q {
 //    return { a in { b in { c in { d in { e in { f in { g in { h in { i in { j in { k in { l in { m in { n in { o in { p in function(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p) } } } } } } } } } } } } } } } }

--- a/Source/Curry.swift
+++ b/Source/Curry.swift
@@ -1,105 +1,247 @@
-public func curry<A, B>(function: (A) -> B) -> A -> B {
-    return function
+public func curry<A, B>(function: (A) -> B)(_ `a`: A) -> B {
+    return function(`a`)
 }
 
-public func curry<A, B, C>(function: (A, B) -> C) -> A -> B -> C {
-    return { a in { b in function(a, b) } }
+public func curry<A, B, C>(function: (A, B) -> C)(_ `a`: A)(_ `b`: B) -> C {
+    return function(`a`, `b`)
 }
 
-public func curry<A, B, C, D>(function: (A, B, C) -> D) -> A -> B -> C -> D {
-    return { a in { b in { c in function(a, b, c) } } }
+public func curry<A, B, C, D>(function: (A, B, C) -> D)(_ `a`: A)(_ `b`: B)(_ `c`: C) -> D {
+    return function(`a`, `b`, `c`)
 }
 
-public func curry<A, B, C, D, E>(function: (A, B, C, D) -> E) -> A -> B -> C -> D -> E {
-    return { a in { b in { c in { d in function(a, b, c, d) } } } }
+public func curry<A, B, C, D, E>(function: (A, B, C, D) -> E)(_ `a`: A)(_ `b`: B)(_ `c`: C)(_ `d`: D) -> E {
+    return function(`a`, `b`, `c`, `d`)
 }
 
-public func curry<A, B, C, D, E, F>(function: (A, B, C, D, E) -> F) -> A -> B -> C -> D -> E -> F {
-    return { a in { b in { c in { d in { e in function(a, b, c, d, e) } } } } }
+public func curry<A, B, C, D, E, F>(function: (A, B, C, D, E) -> F)(_ `a`: A)(_ `b`: B)(_ `c`: C)(_ `d`: D)(_ `e`: E) -> F {
+    return function(`a`, `b`, `c`, `d`, `e`)
 }
 
-public func curry<A, B, C, D, E, F, G>(function: (A, B, C, D, E, F) -> G) -> A -> B -> C -> D -> E -> F -> G {
-    return { a in { b in { c in { d in { e in { f in function(a, b, c, d, e, f) } } } } } }
+public func curry<A, B, C, D, E, F, G>(function: (A, B, C, D, E, F) -> G)(_ `a`: A)(_ `b`: B)(_ `c`: C)(_ `d`: D)(_ `e`: E)(_ `f`: F) -> G {
+    return function(`a`, `b`, `c`, `d`, `e`, `f`)
 }
 
-public func curry<A, B, C, D, E, F, G, H>(function: (A, B, C, D, E, F, G) -> H) -> A -> B -> C -> D -> E -> F -> G -> H {
-    return { a in { b in { c in { d in { e in { f in { g in function(a, b, c, d, e, f, g) } } } } } } }
+public func curry<A, B, C, D, E, F, G, H>(function: (A, B, C, D, E, F, G) -> H)(_ `a`: A)(_ `b`: B)(_ `c`: C)(_ `d`: D)(_ `e`: E)(_ `f`: F)(_ `g`: G) -> H {
+    return function(`a`, `b`, `c`, `d`, `e`, `f`, `g`)
 }
 
-public func curry<A, B, C, D, E, F, G, H, I>(function: (A, B, C, D, E, F, G, H) -> I) -> A -> B -> C -> D -> E -> F -> G -> H -> I {
-    return { a in { b in { c in { d in { e in { f in { g in { h in function(a, b, c, d, e, f, g, h) } } } } } } } }
+public func curry<A, B, C, D, E, F, G, H, I>(function: (A, B, C, D, E, F, G, H) -> I)(_ `a`: A)(_ `b`: B)(_ `c`: C)(_ `d`: D)(_ `e`: E)(_ `f`: F)(_ `g`: G)(_ `h`: H) -> I {
+    return function(`a`, `b`, `c`, `d`, `e`, `f`, `g`, `h`)
 }
 
-public func curry<A, B, C, D, E, F, G, H, I, J>(function: (A, B, C, D, E, F, G, H, I) -> J) -> A -> B -> C -> D -> E -> F -> G -> H -> I -> J {
-    return { a in { b in { c in { d in { e in { f in { g in { h in { i in function(a, b, c, d, e, f, g, h, i) } } } } } } } } }
+public func curry<A, B, C, D, E, F, G, H, I, J>(function: (A, B, C, D, E, F, G, H, I) -> J)(_ `a`: A)(_ `b`: B)(_ `c`: C)(_ `d`: D)(_ `e`: E)(_ `f`: F)(_ `g`: G)(_ `h`: H)(_ `i`: I) -> J {
+    return function(`a`, `b`, `c`, `d`, `e`, `f`, `g`, `h`, `i`)
 }
 
-public func curry<A, B, C, D, E, F, G, H, I, J, K>(function: (A, B, C, D, E, F, G, H, I, J) -> K) -> A -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K {
-    return { a in { b in { c in { d in { e in { f in { g in { h in { i in { j in function(a, b, c, d, e, f, g, h, i, j) } } } } } } } } } }
+public func curry<A, B, C, D, E, F, G, H, I, J, K>(function: (A, B, C, D, E, F, G, H, I, J) -> K)(_ `a`: A)(_ `b`: B)(_ `c`: C)(_ `d`: D)(_ `e`: E)(_ `f`: F)(_ `g`: G)(_ `h`: H)(_ `i`: I)(_ `j`: J) -> K {
+    return function(`a`, `b`, `c`, `d`, `e`, `f`, `g`, `h`, `i`, `j`)
 }
 
-public func curry<A, B, C, D, E, F, G, H, I, J, K, L>(function: (A, B, C, D, E, F, G, H, I, J, K) -> L) -> A -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L {
-    return { a in { b in { c in { d in { e in { f in { g in { h in { i in { j in { k in function(a, b, c, d, e, f, g, h, i, j, k) } } } } } } } } } } }
+public func curry<A, B, C, D, E, F, G, H, I, J, K, L>(function: (A, B, C, D, E, F, G, H, I, J, K) -> L)(_ `a`: A)(_ `b`: B)(_ `c`: C)(_ `d`: D)(_ `e`: E)(_ `f`: F)(_ `g`: G)(_ `h`: H)(_ `i`: I)(_ `j`: J)(_ `k`: K) -> L {
+    return function(`a`, `b`, `c`, `d`, `e`, `f`, `g`, `h`, `i`, `j`, `k`)
 }
 
-public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M>(function: (A, B, C, D, E, F, G, H, I, J, K, L) -> M) -> A -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M {
-    return { a in { b in { c in { d in { e in { f in { g in { h in { i in { j in { k in { l in function(a, b, c, d, e, f, g, h, i, j, k, l) } } } } } } } } } } } }
+public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M>(function: (A, B, C, D, E, F, G, H, I, J, K, L) -> M)(_ `a`: A)(_ `b`: B)(_ `c`: C)(_ `d`: D)(_ `e`: E)(_ `f`: F)(_ `g`: G)(_ `h`: H)(_ `i`: I)(_ `j`: J)(_ `k`: K)(_ `l`: L) -> M {
+    return function(`a`, `b`, `c`, `d`, `e`, `f`, `g`, `h`, `i`, `j`, `k`, `l`)
 }
 
-public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N>(function: (A, B, C, D, E, F, G, H, I, J, K, L, M) -> N) -> A -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N {
-    return { a in { b in { c in { d in { e in { f in { g in { h in { i in { j in { k in { l in { m in function(a, b, c, d, e, f, g, h, i, j, k, l, m) } } } } } } } } } } } } }
+public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N>(function: (A, B, C, D, E, F, G, H, I, J, K, L, M) -> N)(_ `a`: A)(_ `b`: B)(_ `c`: C)(_ `d`: D)(_ `e`: E)(_ `f`: F)(_ `g`: G)(_ `h`: H)(_ `i`: I)(_ `j`: J)(_ `k`: K)(_ `l`: L)(_ `m`: M) -> N {
+    return function(`a`, `b`, `c`, `d`, `e`, `f`, `g`, `h`, `i`, `j`, `k`, `l`, `m`)
 }
 
-public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O>(function: (A, B, C, D, E, F, G, H, I, J, K, L, M, N) -> O) -> A -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O {
-    return { a in { b in { c in { d in { e in { f in { g in { h in { i in { j in { k in { l in { m in { n in function(a, b, c, d, e, f, g, h, i, j, k, l, m, n) } } } } } } } } } } } } } }
+public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O>(function: (A, B, C, D, E, F, G, H, I, J, K, L, M, N) -> O)(_ `a`: A)(_ `b`: B)(_ `c`: C)(_ `d`: D)(_ `e`: E)(_ `f`: F)(_ `g`: G)(_ `h`: H)(_ `i`: I)(_ `j`: J)(_ `k`: K)(_ `l`: L)(_ `m`: M)(_ `n`: N) -> O {
+    return function(`a`, `b`, `c`, `d`, `e`, `f`, `g`, `h`, `i`, `j`, `k`, `l`, `m`, `n`)
 }
 
-public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P>(function: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O) -> P) -> A -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O -> P {
-    return { a in { b in { c in { d in { e in { f in { g in { h in { i in { j in { k in { l in { m in { n in { o in function(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o) } } } } } } } } } } } } } } }
+public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P>(function: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O) -> P)(_ `a`: A)(_ `b`: B)(_ `c`: C)(_ `d`: D)(_ `e`: E)(_ `f`: F)(_ `g`: G)(_ `h`: H)(_ `i`: I)(_ `j`: J)(_ `k`: K)(_ `l`: L)(_ `m`: M)(_ `n`: N)(_ `o`: O) -> P {
+    return function(`a`, `b`, `c`, `d`, `e`, `f`, `g`, `h`, `i`, `j`, `k`, `l`, `m`, `n`, `o`)
 }
 
-// Compile time become exponential past this point
+public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q>(function: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P) -> Q)(_ `a`: A)(_ `b`: B)(_ `c`: C)(_ `d`: D)(_ `e`: E)(_ `f`: F)(_ `g`: G)(_ `h`: H)(_ `i`: I)(_ `j`: J)(_ `k`: K)(_ `l`: L)(_ `m`: M)(_ `n`: N)(_ `o`: O)(_ `p`: P) -> Q {
+    return function(`a`, `b`, `c`, `d`, `e`, `f`, `g`, `h`, `i`, `j`, `k`, `l`, `m`, `n`, `o`, `p`)
+}
 
-//public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q>(function: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P) -> Q) -> A -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O -> P -> Q {
-//    return { a in { b in { c in { d in { e in { f in { g in { h in { i in { j in { k in { l in { m in { n in { o in { p in function(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p) } } } } } } } } } } } } } } } }
-//}
+public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R>(function: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q) -> R)(_ `a`: A)(_ `b`: B)(_ `c`: C)(_ `d`: D)(_ `e`: E)(_ `f`: F)(_ `g`: G)(_ `h`: H)(_ `i`: I)(_ `j`: J)(_ `k`: K)(_ `l`: L)(_ `m`: M)(_ `n`: N)(_ `o`: O)(_ `p`: P)(_ `q`: Q) -> R {
+    return function(`a`, `b`, `c`, `d`, `e`, `f`, `g`, `h`, `i`, `j`, `k`, `l`, `m`, `n`, `o`, `p`, `q`)
+}
 
-//public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R>(function: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q) -> R) -> A -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O -> P -> Q -> R {
-//    return { a in { b in { c in { d in { e in { f in { g in { h in { i in { j in { k in { l in { m in { n in { o in { p in { q in function(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q) } } } } } } } } } } } } } } } } }
-//}
+public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S>(function: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R) -> S)(_ `a`: A)(_ `b`: B)(_ `c`: C)(_ `d`: D)(_ `e`: E)(_ `f`: F)(_ `g`: G)(_ `h`: H)(_ `i`: I)(_ `j`: J)(_ `k`: K)(_ `l`: L)(_ `m`: M)(_ `n`: N)(_ `o`: O)(_ `p`: P)(_ `q`: Q)(_ `r`: R) -> S {
+    return function(`a`, `b`, `c`, `d`, `e`, `f`, `g`, `h`, `i`, `j`, `k`, `l`, `m`, `n`, `o`, `p`, `q`, `r`)
+}
 
-//public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S>(function: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R) -> S) -> A -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O -> P -> Q -> R -> S {
-//    return { a in { b in { c in { d in { e in { f in { g in { h in { i in { j in { k in { l in { m in { n in { o in { p in { q in { r in function(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r) } } } } } } } } } } } } } } } } } }
-//}
+public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T>(function: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S) -> T)(_ `a`: A)(_ `b`: B)(_ `c`: C)(_ `d`: D)(_ `e`: E)(_ `f`: F)(_ `g`: G)(_ `h`: H)(_ `i`: I)(_ `j`: J)(_ `k`: K)(_ `l`: L)(_ `m`: M)(_ `n`: N)(_ `o`: O)(_ `p`: P)(_ `q`: Q)(_ `r`: R)(_ `s`: S) -> T {
+    return function(`a`, `b`, `c`, `d`, `e`, `f`, `g`, `h`, `i`, `j`, `k`, `l`, `m`, `n`, `o`, `p`, `q`, `r`, `s`)
+}
 
-//public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T>(function: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S) -> T) -> A -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O -> P -> Q -> R -> S -> T {
-//    return { a in { b in { c in { d in { e in { f in { g in { h in { i in { j in { k in { l in { m in { n in { o in { p in { q in { r in { s in function(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s) } } } } } } } } } } } } } } } } } } }
-//}
+public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U>(function: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T) -> U)(_ `a`: A)(_ `b`: B)(_ `c`: C)(_ `d`: D)(_ `e`: E)(_ `f`: F)(_ `g`: G)(_ `h`: H)(_ `i`: I)(_ `j`: J)(_ `k`: K)(_ `l`: L)(_ `m`: M)(_ `n`: N)(_ `o`: O)(_ `p`: P)(_ `q`: Q)(_ `r`: R)(_ `s`: S)(_ `t`: T) -> U {
+    return function(`a`, `b`, `c`, `d`, `e`, `f`, `g`, `h`, `i`, `j`, `k`, `l`, `m`, `n`, `o`, `p`, `q`, `r`, `s`, `t`)
+}
 
-//public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U>(function: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T) -> U) -> A -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O -> P -> Q -> R -> S -> T -> U {
-//    return { a in { b in { c in { d in { e in { f in { g in { h in { i in { j in { k in { l in { m in { n in { o in { p in { q in { r in { s in { t in function(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t) } } } } } } } } } } } } } } } } } } } }
-//}
+public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V>(function: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U) -> V)(_ `a`: A)(_ `b`: B)(_ `c`: C)(_ `d`: D)(_ `e`: E)(_ `f`: F)(_ `g`: G)(_ `h`: H)(_ `i`: I)(_ `j`: J)(_ `k`: K)(_ `l`: L)(_ `m`: M)(_ `n`: N)(_ `o`: O)(_ `p`: P)(_ `q`: Q)(_ `r`: R)(_ `s`: S)(_ `t`: T)(_ `u`: U) -> V {
+    return function(`a`, `b`, `c`, `d`, `e`, `f`, `g`, `h`, `i`, `j`, `k`, `l`, `m`, `n`, `o`, `p`, `q`, `r`, `s`, `t`, `u`)
+}
 
-//public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V>(function: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U) -> V) -> A -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O -> P -> Q -> R -> S -> T -> U -> V {
-//    return { a in { b in { c in { d in { e in { f in { g in { h in { i in { j in { k in { l in { m in { n in { o in { p in { q in { r in { s in { t in { u in function(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u) } } } } } } } } } } } } } } } } } } } } }
-//}
+public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W>(function: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V) -> W)(_ `a`: A)(_ `b`: B)(_ `c`: C)(_ `d`: D)(_ `e`: E)(_ `f`: F)(_ `g`: G)(_ `h`: H)(_ `i`: I)(_ `j`: J)(_ `k`: K)(_ `l`: L)(_ `m`: M)(_ `n`: N)(_ `o`: O)(_ `p`: P)(_ `q`: Q)(_ `r`: R)(_ `s`: S)(_ `t`: T)(_ `u`: U)(_ `v`: V) -> W {
+    return function(`a`, `b`, `c`, `d`, `e`, `f`, `g`, `h`, `i`, `j`, `k`, `l`, `m`, `n`, `o`, `p`, `q`, `r`, `s`, `t`, `u`, `v`)
+}
 
-//public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W>(function: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V) -> W) -> A -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O -> P -> Q -> R -> S -> T -> U -> V -> W {
-//    return { a in { b in { c in { d in { e in { f in { g in { h in { i in { j in { k in { l in { m in { n in { o in { p in { q in { r in { s in { t in { u in { v in function(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v) } } } } } } } } } } } } } } } } } } } } } }
-//}
+public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X>(function: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W) -> X)(_ `a`: A)(_ `b`: B)(_ `c`: C)(_ `d`: D)(_ `e`: E)(_ `f`: F)(_ `g`: G)(_ `h`: H)(_ `i`: I)(_ `j`: J)(_ `k`: K)(_ `l`: L)(_ `m`: M)(_ `n`: N)(_ `o`: O)(_ `p`: P)(_ `q`: Q)(_ `r`: R)(_ `s`: S)(_ `t`: T)(_ `u`: U)(_ `v`: V)(_ `w`: W) -> X {
+    return function(`a`, `b`, `c`, `d`, `e`, `f`, `g`, `h`, `i`, `j`, `k`, `l`, `m`, `n`, `o`, `p`, `q`, `r`, `s`, `t`, `u`, `v`, `w`)
+}
 
-//public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X>(function: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W) -> X) -> A -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O -> P -> Q -> R -> S -> T -> U -> V -> W -> X {
-//    return { a in { b in { c in { d in { e in { f in { g in { h in { i in { j in { k in { l in { m in { n in { o in { p in { q in { r in { s in { t in { u in { v in { w in function(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w) } } } } } } } } } } } } } } } } } } } } } } }
-//}
+public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y>(function: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X) -> Y)(_ `a`: A)(_ `b`: B)(_ `c`: C)(_ `d`: D)(_ `e`: E)(_ `f`: F)(_ `g`: G)(_ `h`: H)(_ `i`: I)(_ `j`: J)(_ `k`: K)(_ `l`: L)(_ `m`: M)(_ `n`: N)(_ `o`: O)(_ `p`: P)(_ `q`: Q)(_ `r`: R)(_ `s`: S)(_ `t`: T)(_ `u`: U)(_ `v`: V)(_ `w`: W)(_ `x`: X) -> Y {
+    return function(`a`, `b`, `c`, `d`, `e`, `f`, `g`, `h`, `i`, `j`, `k`, `l`, `m`, `n`, `o`, `p`, `q`, `r`, `s`, `t`, `u`, `v`, `w`, `x`)
+}
 
-//public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y>(function: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X) -> Y) -> A -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O -> P -> Q -> R -> S -> T -> U -> V -> W -> X -> Y {
-//    return { a in { b in { c in { d in { e in { f in { g in { h in { i in { j in { k in { l in { m in { n in { o in { p in { q in { r in { s in { t in { u in { v in { w in { x in function(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x) } } } } } } } } } } } } } } } } } } } } } } } }
-//}
+public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z>(function: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y) -> Z)(_ `a`: A)(_ `b`: B)(_ `c`: C)(_ `d`: D)(_ `e`: E)(_ `f`: F)(_ `g`: G)(_ `h`: H)(_ `i`: I)(_ `j`: J)(_ `k`: K)(_ `l`: L)(_ `m`: M)(_ `n`: N)(_ `o`: O)(_ `p`: P)(_ `q`: Q)(_ `r`: R)(_ `s`: S)(_ `t`: T)(_ `u`: U)(_ `v`: V)(_ `w`: W)(_ `x`: X)(_ `y`: Y) -> Z {
+    return function(`a`, `b`, `c`, `d`, `e`, `f`, `g`, `h`, `i`, `j`, `k`, `l`, `m`, `n`, `o`, `p`, `q`, `r`, `s`, `t`, `u`, `v`, `w`, `x`, `y`)
+}
 
-//public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z>(function: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y) -> Z) -> A -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O -> P -> Q -> R -> S -> T -> U -> V -> W -> X -> Y -> Z {
-//    return { a in { b in { c in { d in { e in { f in { g in { h in { i in { j in { k in { l in { m in { n in { o in { p in { q in { r in { s in { t in { u in { v in { w in { x in { y in function(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y) } } } } } } } } } } } } } } } } } } } } } } } } }
-//}
+public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AA>(function: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z) -> AA)(_ `a`: A)(_ `b`: B)(_ `c`: C)(_ `d`: D)(_ `e`: E)(_ `f`: F)(_ `g`: G)(_ `h`: H)(_ `i`: I)(_ `j`: J)(_ `k`: K)(_ `l`: L)(_ `m`: M)(_ `n`: N)(_ `o`: O)(_ `p`: P)(_ `q`: Q)(_ `r`: R)(_ `s`: S)(_ `t`: T)(_ `u`: U)(_ `v`: V)(_ `w`: W)(_ `x`: X)(_ `y`: Y)(_ `z`: Z) -> AA {
+    return function(`a`, `b`, `c`, `d`, `e`, `f`, `g`, `h`, `i`, `j`, `k`, `l`, `m`, `n`, `o`, `p`, `q`, `r`, `s`, `t`, `u`, `v`, `w`, `x`, `y`, `z`)
+}
 
-//public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AA>(function: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z) -> AA) -> A -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O -> P -> Q -> R -> S -> T -> U -> V -> W -> X -> Y -> Z -> AA {
-//    return { a in { b in { c in { d in { e in { f in { g in { h in { i in { j in { k in { l in { m in { n in { o in { p in { q in { r in { s in { t in { u in { v in { w in { x in { y in { z in function(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z) } } } } } } } } } } } } } } } } } } } } } } } } } }
-//}
+public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AA, AB>(function: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AA) -> AB)(_ `a`: A)(_ `b`: B)(_ `c`: C)(_ `d`: D)(_ `e`: E)(_ `f`: F)(_ `g`: G)(_ `h`: H)(_ `i`: I)(_ `j`: J)(_ `k`: K)(_ `l`: L)(_ `m`: M)(_ `n`: N)(_ `o`: O)(_ `p`: P)(_ `q`: Q)(_ `r`: R)(_ `s`: S)(_ `t`: T)(_ `u`: U)(_ `v`: V)(_ `w`: W)(_ `x`: X)(_ `y`: Y)(_ `z`: Z)(_ `aa`: AA) -> AB {
+    return function(`a`, `b`, `c`, `d`, `e`, `f`, `g`, `h`, `i`, `j`, `k`, `l`, `m`, `n`, `o`, `p`, `q`, `r`, `s`, `t`, `u`, `v`, `w`, `x`, `y`, `z`, `aa`)
+}
+
+public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AA, AB, AC>(function: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AA, AB) -> AC)(_ `a`: A)(_ `b`: B)(_ `c`: C)(_ `d`: D)(_ `e`: E)(_ `f`: F)(_ `g`: G)(_ `h`: H)(_ `i`: I)(_ `j`: J)(_ `k`: K)(_ `l`: L)(_ `m`: M)(_ `n`: N)(_ `o`: O)(_ `p`: P)(_ `q`: Q)(_ `r`: R)(_ `s`: S)(_ `t`: T)(_ `u`: U)(_ `v`: V)(_ `w`: W)(_ `x`: X)(_ `y`: Y)(_ `z`: Z)(_ `aa`: AA)(_ `ab`: AB) -> AC {
+    return function(`a`, `b`, `c`, `d`, `e`, `f`, `g`, `h`, `i`, `j`, `k`, `l`, `m`, `n`, `o`, `p`, `q`, `r`, `s`, `t`, `u`, `v`, `w`, `x`, `y`, `z`, `aa`, `ab`)
+}
+
+public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AA, AB, AC, AD>(function: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AA, AB, AC) -> AD)(_ `a`: A)(_ `b`: B)(_ `c`: C)(_ `d`: D)(_ `e`: E)(_ `f`: F)(_ `g`: G)(_ `h`: H)(_ `i`: I)(_ `j`: J)(_ `k`: K)(_ `l`: L)(_ `m`: M)(_ `n`: N)(_ `o`: O)(_ `p`: P)(_ `q`: Q)(_ `r`: R)(_ `s`: S)(_ `t`: T)(_ `u`: U)(_ `v`: V)(_ `w`: W)(_ `x`: X)(_ `y`: Y)(_ `z`: Z)(_ `aa`: AA)(_ `ab`: AB)(_ `ac`: AC) -> AD {
+    return function(`a`, `b`, `c`, `d`, `e`, `f`, `g`, `h`, `i`, `j`, `k`, `l`, `m`, `n`, `o`, `p`, `q`, `r`, `s`, `t`, `u`, `v`, `w`, `x`, `y`, `z`, `aa`, `ab`, `ac`)
+}
+
+public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AA, AB, AC, AD, AE>(function: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AA, AB, AC, AD) -> AE)(_ `a`: A)(_ `b`: B)(_ `c`: C)(_ `d`: D)(_ `e`: E)(_ `f`: F)(_ `g`: G)(_ `h`: H)(_ `i`: I)(_ `j`: J)(_ `k`: K)(_ `l`: L)(_ `m`: M)(_ `n`: N)(_ `o`: O)(_ `p`: P)(_ `q`: Q)(_ `r`: R)(_ `s`: S)(_ `t`: T)(_ `u`: U)(_ `v`: V)(_ `w`: W)(_ `x`: X)(_ `y`: Y)(_ `z`: Z)(_ `aa`: AA)(_ `ab`: AB)(_ `ac`: AC)(_ `ad`: AD) -> AE {
+    return function(`a`, `b`, `c`, `d`, `e`, `f`, `g`, `h`, `i`, `j`, `k`, `l`, `m`, `n`, `o`, `p`, `q`, `r`, `s`, `t`, `u`, `v`, `w`, `x`, `y`, `z`, `aa`, `ab`, `ac`, `ad`)
+}
+
+public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AA, AB, AC, AD, AE, AF>(function: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AA, AB, AC, AD, AE) -> AF)(_ `a`: A)(_ `b`: B)(_ `c`: C)(_ `d`: D)(_ `e`: E)(_ `f`: F)(_ `g`: G)(_ `h`: H)(_ `i`: I)(_ `j`: J)(_ `k`: K)(_ `l`: L)(_ `m`: M)(_ `n`: N)(_ `o`: O)(_ `p`: P)(_ `q`: Q)(_ `r`: R)(_ `s`: S)(_ `t`: T)(_ `u`: U)(_ `v`: V)(_ `w`: W)(_ `x`: X)(_ `y`: Y)(_ `z`: Z)(_ `aa`: AA)(_ `ab`: AB)(_ `ac`: AC)(_ `ad`: AD)(_ `ae`: AE) -> AF {
+    return function(`a`, `b`, `c`, `d`, `e`, `f`, `g`, `h`, `i`, `j`, `k`, `l`, `m`, `n`, `o`, `p`, `q`, `r`, `s`, `t`, `u`, `v`, `w`, `x`, `y`, `z`, `aa`, `ab`, `ac`, `ad`, `ae`)
+}
+
+public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AA, AB, AC, AD, AE, AF, AG>(function: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AA, AB, AC, AD, AE, AF) -> AG)(_ `a`: A)(_ `b`: B)(_ `c`: C)(_ `d`: D)(_ `e`: E)(_ `f`: F)(_ `g`: G)(_ `h`: H)(_ `i`: I)(_ `j`: J)(_ `k`: K)(_ `l`: L)(_ `m`: M)(_ `n`: N)(_ `o`: O)(_ `p`: P)(_ `q`: Q)(_ `r`: R)(_ `s`: S)(_ `t`: T)(_ `u`: U)(_ `v`: V)(_ `w`: W)(_ `x`: X)(_ `y`: Y)(_ `z`: Z)(_ `aa`: AA)(_ `ab`: AB)(_ `ac`: AC)(_ `ad`: AD)(_ `ae`: AE)(_ `af`: AF) -> AG {
+    return function(`a`, `b`, `c`, `d`, `e`, `f`, `g`, `h`, `i`, `j`, `k`, `l`, `m`, `n`, `o`, `p`, `q`, `r`, `s`, `t`, `u`, `v`, `w`, `x`, `y`, `z`, `aa`, `ab`, `ac`, `ad`, `ae`, `af`)
+}
+
+public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AA, AB, AC, AD, AE, AF, AG, AH>(function: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AA, AB, AC, AD, AE, AF, AG) -> AH)(_ `a`: A)(_ `b`: B)(_ `c`: C)(_ `d`: D)(_ `e`: E)(_ `f`: F)(_ `g`: G)(_ `h`: H)(_ `i`: I)(_ `j`: J)(_ `k`: K)(_ `l`: L)(_ `m`: M)(_ `n`: N)(_ `o`: O)(_ `p`: P)(_ `q`: Q)(_ `r`: R)(_ `s`: S)(_ `t`: T)(_ `u`: U)(_ `v`: V)(_ `w`: W)(_ `x`: X)(_ `y`: Y)(_ `z`: Z)(_ `aa`: AA)(_ `ab`: AB)(_ `ac`: AC)(_ `ad`: AD)(_ `ae`: AE)(_ `af`: AF)(_ `ag`: AG) -> AH {
+    return function(`a`, `b`, `c`, `d`, `e`, `f`, `g`, `h`, `i`, `j`, `k`, `l`, `m`, `n`, `o`, `p`, `q`, `r`, `s`, `t`, `u`, `v`, `w`, `x`, `y`, `z`, `aa`, `ab`, `ac`, `ad`, `ae`, `af`, `ag`)
+}
+
+public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AA, AB, AC, AD, AE, AF, AG, AH, AI>(function: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AA, AB, AC, AD, AE, AF, AG, AH) -> AI)(_ `a`: A)(_ `b`: B)(_ `c`: C)(_ `d`: D)(_ `e`: E)(_ `f`: F)(_ `g`: G)(_ `h`: H)(_ `i`: I)(_ `j`: J)(_ `k`: K)(_ `l`: L)(_ `m`: M)(_ `n`: N)(_ `o`: O)(_ `p`: P)(_ `q`: Q)(_ `r`: R)(_ `s`: S)(_ `t`: T)(_ `u`: U)(_ `v`: V)(_ `w`: W)(_ `x`: X)(_ `y`: Y)(_ `z`: Z)(_ `aa`: AA)(_ `ab`: AB)(_ `ac`: AC)(_ `ad`: AD)(_ `ae`: AE)(_ `af`: AF)(_ `ag`: AG)(_ `ah`: AH) -> AI {
+    return function(`a`, `b`, `c`, `d`, `e`, `f`, `g`, `h`, `i`, `j`, `k`, `l`, `m`, `n`, `o`, `p`, `q`, `r`, `s`, `t`, `u`, `v`, `w`, `x`, `y`, `z`, `aa`, `ab`, `ac`, `ad`, `ae`, `af`, `ag`, `ah`)
+}
+
+public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AA, AB, AC, AD, AE, AF, AG, AH, AI, AJ>(function: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AA, AB, AC, AD, AE, AF, AG, AH, AI) -> AJ)(_ `a`: A)(_ `b`: B)(_ `c`: C)(_ `d`: D)(_ `e`: E)(_ `f`: F)(_ `g`: G)(_ `h`: H)(_ `i`: I)(_ `j`: J)(_ `k`: K)(_ `l`: L)(_ `m`: M)(_ `n`: N)(_ `o`: O)(_ `p`: P)(_ `q`: Q)(_ `r`: R)(_ `s`: S)(_ `t`: T)(_ `u`: U)(_ `v`: V)(_ `w`: W)(_ `x`: X)(_ `y`: Y)(_ `z`: Z)(_ `aa`: AA)(_ `ab`: AB)(_ `ac`: AC)(_ `ad`: AD)(_ `ae`: AE)(_ `af`: AF)(_ `ag`: AG)(_ `ah`: AH)(_ `ai`: AI) -> AJ {
+    return function(`a`, `b`, `c`, `d`, `e`, `f`, `g`, `h`, `i`, `j`, `k`, `l`, `m`, `n`, `o`, `p`, `q`, `r`, `s`, `t`, `u`, `v`, `w`, `x`, `y`, `z`, `aa`, `ab`, `ac`, `ad`, `ae`, `af`, `ag`, `ah`, `ai`)
+}
+
+public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AA, AB, AC, AD, AE, AF, AG, AH, AI, AJ, AK>(function: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AA, AB, AC, AD, AE, AF, AG, AH, AI, AJ) -> AK)(_ `a`: A)(_ `b`: B)(_ `c`: C)(_ `d`: D)(_ `e`: E)(_ `f`: F)(_ `g`: G)(_ `h`: H)(_ `i`: I)(_ `j`: J)(_ `k`: K)(_ `l`: L)(_ `m`: M)(_ `n`: N)(_ `o`: O)(_ `p`: P)(_ `q`: Q)(_ `r`: R)(_ `s`: S)(_ `t`: T)(_ `u`: U)(_ `v`: V)(_ `w`: W)(_ `x`: X)(_ `y`: Y)(_ `z`: Z)(_ `aa`: AA)(_ `ab`: AB)(_ `ac`: AC)(_ `ad`: AD)(_ `ae`: AE)(_ `af`: AF)(_ `ag`: AG)(_ `ah`: AH)(_ `ai`: AI)(_ `aj`: AJ) -> AK {
+    return function(`a`, `b`, `c`, `d`, `e`, `f`, `g`, `h`, `i`, `j`, `k`, `l`, `m`, `n`, `o`, `p`, `q`, `r`, `s`, `t`, `u`, `v`, `w`, `x`, `y`, `z`, `aa`, `ab`, `ac`, `ad`, `ae`, `af`, `ag`, `ah`, `ai`, `aj`)
+}
+
+public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AA, AB, AC, AD, AE, AF, AG, AH, AI, AJ, AK, AL>(function: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AA, AB, AC, AD, AE, AF, AG, AH, AI, AJ, AK) -> AL)(_ `a`: A)(_ `b`: B)(_ `c`: C)(_ `d`: D)(_ `e`: E)(_ `f`: F)(_ `g`: G)(_ `h`: H)(_ `i`: I)(_ `j`: J)(_ `k`: K)(_ `l`: L)(_ `m`: M)(_ `n`: N)(_ `o`: O)(_ `p`: P)(_ `q`: Q)(_ `r`: R)(_ `s`: S)(_ `t`: T)(_ `u`: U)(_ `v`: V)(_ `w`: W)(_ `x`: X)(_ `y`: Y)(_ `z`: Z)(_ `aa`: AA)(_ `ab`: AB)(_ `ac`: AC)(_ `ad`: AD)(_ `ae`: AE)(_ `af`: AF)(_ `ag`: AG)(_ `ah`: AH)(_ `ai`: AI)(_ `aj`: AJ)(_ `ak`: AK) -> AL {
+    return function(`a`, `b`, `c`, `d`, `e`, `f`, `g`, `h`, `i`, `j`, `k`, `l`, `m`, `n`, `o`, `p`, `q`, `r`, `s`, `t`, `u`, `v`, `w`, `x`, `y`, `z`, `aa`, `ab`, `ac`, `ad`, `ae`, `af`, `ag`, `ah`, `ai`, `aj`, `ak`)
+}
+
+public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AA, AB, AC, AD, AE, AF, AG, AH, AI, AJ, AK, AL, AM>(function: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AA, AB, AC, AD, AE, AF, AG, AH, AI, AJ, AK, AL) -> AM)(_ `a`: A)(_ `b`: B)(_ `c`: C)(_ `d`: D)(_ `e`: E)(_ `f`: F)(_ `g`: G)(_ `h`: H)(_ `i`: I)(_ `j`: J)(_ `k`: K)(_ `l`: L)(_ `m`: M)(_ `n`: N)(_ `o`: O)(_ `p`: P)(_ `q`: Q)(_ `r`: R)(_ `s`: S)(_ `t`: T)(_ `u`: U)(_ `v`: V)(_ `w`: W)(_ `x`: X)(_ `y`: Y)(_ `z`: Z)(_ `aa`: AA)(_ `ab`: AB)(_ `ac`: AC)(_ `ad`: AD)(_ `ae`: AE)(_ `af`: AF)(_ `ag`: AG)(_ `ah`: AH)(_ `ai`: AI)(_ `aj`: AJ)(_ `ak`: AK)(_ `al`: AL) -> AM {
+    return function(`a`, `b`, `c`, `d`, `e`, `f`, `g`, `h`, `i`, `j`, `k`, `l`, `m`, `n`, `o`, `p`, `q`, `r`, `s`, `t`, `u`, `v`, `w`, `x`, `y`, `z`, `aa`, `ab`, `ac`, `ad`, `ae`, `af`, `ag`, `ah`, `ai`, `aj`, `ak`, `al`)
+}
+
+public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AA, AB, AC, AD, AE, AF, AG, AH, AI, AJ, AK, AL, AM, AN>(function: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AA, AB, AC, AD, AE, AF, AG, AH, AI, AJ, AK, AL, AM) -> AN)(_ `a`: A)(_ `b`: B)(_ `c`: C)(_ `d`: D)(_ `e`: E)(_ `f`: F)(_ `g`: G)(_ `h`: H)(_ `i`: I)(_ `j`: J)(_ `k`: K)(_ `l`: L)(_ `m`: M)(_ `n`: N)(_ `o`: O)(_ `p`: P)(_ `q`: Q)(_ `r`: R)(_ `s`: S)(_ `t`: T)(_ `u`: U)(_ `v`: V)(_ `w`: W)(_ `x`: X)(_ `y`: Y)(_ `z`: Z)(_ `aa`: AA)(_ `ab`: AB)(_ `ac`: AC)(_ `ad`: AD)(_ `ae`: AE)(_ `af`: AF)(_ `ag`: AG)(_ `ah`: AH)(_ `ai`: AI)(_ `aj`: AJ)(_ `ak`: AK)(_ `al`: AL)(_ `am`: AM) -> AN {
+    return function(`a`, `b`, `c`, `d`, `e`, `f`, `g`, `h`, `i`, `j`, `k`, `l`, `m`, `n`, `o`, `p`, `q`, `r`, `s`, `t`, `u`, `v`, `w`, `x`, `y`, `z`, `aa`, `ab`, `ac`, `ad`, `ae`, `af`, `ag`, `ah`, `ai`, `aj`, `ak`, `al`, `am`)
+}
+
+public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AA, AB, AC, AD, AE, AF, AG, AH, AI, AJ, AK, AL, AM, AN, AO>(function: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AA, AB, AC, AD, AE, AF, AG, AH, AI, AJ, AK, AL, AM, AN) -> AO)(_ `a`: A)(_ `b`: B)(_ `c`: C)(_ `d`: D)(_ `e`: E)(_ `f`: F)(_ `g`: G)(_ `h`: H)(_ `i`: I)(_ `j`: J)(_ `k`: K)(_ `l`: L)(_ `m`: M)(_ `n`: N)(_ `o`: O)(_ `p`: P)(_ `q`: Q)(_ `r`: R)(_ `s`: S)(_ `t`: T)(_ `u`: U)(_ `v`: V)(_ `w`: W)(_ `x`: X)(_ `y`: Y)(_ `z`: Z)(_ `aa`: AA)(_ `ab`: AB)(_ `ac`: AC)(_ `ad`: AD)(_ `ae`: AE)(_ `af`: AF)(_ `ag`: AG)(_ `ah`: AH)(_ `ai`: AI)(_ `aj`: AJ)(_ `ak`: AK)(_ `al`: AL)(_ `am`: AM)(_ `an`: AN) -> AO {
+    return function(`a`, `b`, `c`, `d`, `e`, `f`, `g`, `h`, `i`, `j`, `k`, `l`, `m`, `n`, `o`, `p`, `q`, `r`, `s`, `t`, `u`, `v`, `w`, `x`, `y`, `z`, `aa`, `ab`, `ac`, `ad`, `ae`, `af`, `ag`, `ah`, `ai`, `aj`, `ak`, `al`, `am`, `an`)
+}
+
+public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AA, AB, AC, AD, AE, AF, AG, AH, AI, AJ, AK, AL, AM, AN, AO, AP>(function: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AA, AB, AC, AD, AE, AF, AG, AH, AI, AJ, AK, AL, AM, AN, AO) -> AP)(_ `a`: A)(_ `b`: B)(_ `c`: C)(_ `d`: D)(_ `e`: E)(_ `f`: F)(_ `g`: G)(_ `h`: H)(_ `i`: I)(_ `j`: J)(_ `k`: K)(_ `l`: L)(_ `m`: M)(_ `n`: N)(_ `o`: O)(_ `p`: P)(_ `q`: Q)(_ `r`: R)(_ `s`: S)(_ `t`: T)(_ `u`: U)(_ `v`: V)(_ `w`: W)(_ `x`: X)(_ `y`: Y)(_ `z`: Z)(_ `aa`: AA)(_ `ab`: AB)(_ `ac`: AC)(_ `ad`: AD)(_ `ae`: AE)(_ `af`: AF)(_ `ag`: AG)(_ `ah`: AH)(_ `ai`: AI)(_ `aj`: AJ)(_ `ak`: AK)(_ `al`: AL)(_ `am`: AM)(_ `an`: AN)(_ `ao`: AO) -> AP {
+    return function(`a`, `b`, `c`, `d`, `e`, `f`, `g`, `h`, `i`, `j`, `k`, `l`, `m`, `n`, `o`, `p`, `q`, `r`, `s`, `t`, `u`, `v`, `w`, `x`, `y`, `z`, `aa`, `ab`, `ac`, `ad`, `ae`, `af`, `ag`, `ah`, `ai`, `aj`, `ak`, `al`, `am`, `an`, `ao`)
+}
+
+public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AA, AB, AC, AD, AE, AF, AG, AH, AI, AJ, AK, AL, AM, AN, AO, AP, AQ>(function: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AA, AB, AC, AD, AE, AF, AG, AH, AI, AJ, AK, AL, AM, AN, AO, AP) -> AQ)(_ `a`: A)(_ `b`: B)(_ `c`: C)(_ `d`: D)(_ `e`: E)(_ `f`: F)(_ `g`: G)(_ `h`: H)(_ `i`: I)(_ `j`: J)(_ `k`: K)(_ `l`: L)(_ `m`: M)(_ `n`: N)(_ `o`: O)(_ `p`: P)(_ `q`: Q)(_ `r`: R)(_ `s`: S)(_ `t`: T)(_ `u`: U)(_ `v`: V)(_ `w`: W)(_ `x`: X)(_ `y`: Y)(_ `z`: Z)(_ `aa`: AA)(_ `ab`: AB)(_ `ac`: AC)(_ `ad`: AD)(_ `ae`: AE)(_ `af`: AF)(_ `ag`: AG)(_ `ah`: AH)(_ `ai`: AI)(_ `aj`: AJ)(_ `ak`: AK)(_ `al`: AL)(_ `am`: AM)(_ `an`: AN)(_ `ao`: AO)(_ `ap`: AP) -> AQ {
+    return function(`a`, `b`, `c`, `d`, `e`, `f`, `g`, `h`, `i`, `j`, `k`, `l`, `m`, `n`, `o`, `p`, `q`, `r`, `s`, `t`, `u`, `v`, `w`, `x`, `y`, `z`, `aa`, `ab`, `ac`, `ad`, `ae`, `af`, `ag`, `ah`, `ai`, `aj`, `ak`, `al`, `am`, `an`, `ao`, `ap`)
+}
+
+public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AA, AB, AC, AD, AE, AF, AG, AH, AI, AJ, AK, AL, AM, AN, AO, AP, AQ, AR>(function: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AA, AB, AC, AD, AE, AF, AG, AH, AI, AJ, AK, AL, AM, AN, AO, AP, AQ) -> AR)(_ `a`: A)(_ `b`: B)(_ `c`: C)(_ `d`: D)(_ `e`: E)(_ `f`: F)(_ `g`: G)(_ `h`: H)(_ `i`: I)(_ `j`: J)(_ `k`: K)(_ `l`: L)(_ `m`: M)(_ `n`: N)(_ `o`: O)(_ `p`: P)(_ `q`: Q)(_ `r`: R)(_ `s`: S)(_ `t`: T)(_ `u`: U)(_ `v`: V)(_ `w`: W)(_ `x`: X)(_ `y`: Y)(_ `z`: Z)(_ `aa`: AA)(_ `ab`: AB)(_ `ac`: AC)(_ `ad`: AD)(_ `ae`: AE)(_ `af`: AF)(_ `ag`: AG)(_ `ah`: AH)(_ `ai`: AI)(_ `aj`: AJ)(_ `ak`: AK)(_ `al`: AL)(_ `am`: AM)(_ `an`: AN)(_ `ao`: AO)(_ `ap`: AP)(_ `aq`: AQ) -> AR {
+    return function(`a`, `b`, `c`, `d`, `e`, `f`, `g`, `h`, `i`, `j`, `k`, `l`, `m`, `n`, `o`, `p`, `q`, `r`, `s`, `t`, `u`, `v`, `w`, `x`, `y`, `z`, `aa`, `ab`, `ac`, `ad`, `ae`, `af`, `ag`, `ah`, `ai`, `aj`, `ak`, `al`, `am`, `an`, `ao`, `ap`, `aq`)
+}
+
+public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AA, AB, AC, AD, AE, AF, AG, AH, AI, AJ, AK, AL, AM, AN, AO, AP, AQ, AR, AS>(function: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AA, AB, AC, AD, AE, AF, AG, AH, AI, AJ, AK, AL, AM, AN, AO, AP, AQ, AR) -> AS)(_ `a`: A)(_ `b`: B)(_ `c`: C)(_ `d`: D)(_ `e`: E)(_ `f`: F)(_ `g`: G)(_ `h`: H)(_ `i`: I)(_ `j`: J)(_ `k`: K)(_ `l`: L)(_ `m`: M)(_ `n`: N)(_ `o`: O)(_ `p`: P)(_ `q`: Q)(_ `r`: R)(_ `s`: S)(_ `t`: T)(_ `u`: U)(_ `v`: V)(_ `w`: W)(_ `x`: X)(_ `y`: Y)(_ `z`: Z)(_ `aa`: AA)(_ `ab`: AB)(_ `ac`: AC)(_ `ad`: AD)(_ `ae`: AE)(_ `af`: AF)(_ `ag`: AG)(_ `ah`: AH)(_ `ai`: AI)(_ `aj`: AJ)(_ `ak`: AK)(_ `al`: AL)(_ `am`: AM)(_ `an`: AN)(_ `ao`: AO)(_ `ap`: AP)(_ `aq`: AQ)(_ `ar`: AR) -> AS {
+    return function(`a`, `b`, `c`, `d`, `e`, `f`, `g`, `h`, `i`, `j`, `k`, `l`, `m`, `n`, `o`, `p`, `q`, `r`, `s`, `t`, `u`, `v`, `w`, `x`, `y`, `z`, `aa`, `ab`, `ac`, `ad`, `ae`, `af`, `ag`, `ah`, `ai`, `aj`, `ak`, `al`, `am`, `an`, `ao`, `ap`, `aq`, `ar`)
+}
+
+public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AA, AB, AC, AD, AE, AF, AG, AH, AI, AJ, AK, AL, AM, AN, AO, AP, AQ, AR, AS, AT>(function: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AA, AB, AC, AD, AE, AF, AG, AH, AI, AJ, AK, AL, AM, AN, AO, AP, AQ, AR, AS) -> AT)(_ `a`: A)(_ `b`: B)(_ `c`: C)(_ `d`: D)(_ `e`: E)(_ `f`: F)(_ `g`: G)(_ `h`: H)(_ `i`: I)(_ `j`: J)(_ `k`: K)(_ `l`: L)(_ `m`: M)(_ `n`: N)(_ `o`: O)(_ `p`: P)(_ `q`: Q)(_ `r`: R)(_ `s`: S)(_ `t`: T)(_ `u`: U)(_ `v`: V)(_ `w`: W)(_ `x`: X)(_ `y`: Y)(_ `z`: Z)(_ `aa`: AA)(_ `ab`: AB)(_ `ac`: AC)(_ `ad`: AD)(_ `ae`: AE)(_ `af`: AF)(_ `ag`: AG)(_ `ah`: AH)(_ `ai`: AI)(_ `aj`: AJ)(_ `ak`: AK)(_ `al`: AL)(_ `am`: AM)(_ `an`: AN)(_ `ao`: AO)(_ `ap`: AP)(_ `aq`: AQ)(_ `ar`: AR)(_ `as`: AS) -> AT {
+    return function(`a`, `b`, `c`, `d`, `e`, `f`, `g`, `h`, `i`, `j`, `k`, `l`, `m`, `n`, `o`, `p`, `q`, `r`, `s`, `t`, `u`, `v`, `w`, `x`, `y`, `z`, `aa`, `ab`, `ac`, `ad`, `ae`, `af`, `ag`, `ah`, `ai`, `aj`, `ak`, `al`, `am`, `an`, `ao`, `ap`, `aq`, `ar`, `as`)
+}
+
+public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AA, AB, AC, AD, AE, AF, AG, AH, AI, AJ, AK, AL, AM, AN, AO, AP, AQ, AR, AS, AT, AU>(function: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AA, AB, AC, AD, AE, AF, AG, AH, AI, AJ, AK, AL, AM, AN, AO, AP, AQ, AR, AS, AT) -> AU)(_ `a`: A)(_ `b`: B)(_ `c`: C)(_ `d`: D)(_ `e`: E)(_ `f`: F)(_ `g`: G)(_ `h`: H)(_ `i`: I)(_ `j`: J)(_ `k`: K)(_ `l`: L)(_ `m`: M)(_ `n`: N)(_ `o`: O)(_ `p`: P)(_ `q`: Q)(_ `r`: R)(_ `s`: S)(_ `t`: T)(_ `u`: U)(_ `v`: V)(_ `w`: W)(_ `x`: X)(_ `y`: Y)(_ `z`: Z)(_ `aa`: AA)(_ `ab`: AB)(_ `ac`: AC)(_ `ad`: AD)(_ `ae`: AE)(_ `af`: AF)(_ `ag`: AG)(_ `ah`: AH)(_ `ai`: AI)(_ `aj`: AJ)(_ `ak`: AK)(_ `al`: AL)(_ `am`: AM)(_ `an`: AN)(_ `ao`: AO)(_ `ap`: AP)(_ `aq`: AQ)(_ `ar`: AR)(_ `as`: AS)(_ `at`: AT) -> AU {
+    return function(`a`, `b`, `c`, `d`, `e`, `f`, `g`, `h`, `i`, `j`, `k`, `l`, `m`, `n`, `o`, `p`, `q`, `r`, `s`, `t`, `u`, `v`, `w`, `x`, `y`, `z`, `aa`, `ab`, `ac`, `ad`, `ae`, `af`, `ag`, `ah`, `ai`, `aj`, `ak`, `al`, `am`, `an`, `ao`, `ap`, `aq`, `ar`, `as`, `at`)
+}
+
+public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AA, AB, AC, AD, AE, AF, AG, AH, AI, AJ, AK, AL, AM, AN, AO, AP, AQ, AR, AS, AT, AU, AV>(function: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AA, AB, AC, AD, AE, AF, AG, AH, AI, AJ, AK, AL, AM, AN, AO, AP, AQ, AR, AS, AT, AU) -> AV)(_ `a`: A)(_ `b`: B)(_ `c`: C)(_ `d`: D)(_ `e`: E)(_ `f`: F)(_ `g`: G)(_ `h`: H)(_ `i`: I)(_ `j`: J)(_ `k`: K)(_ `l`: L)(_ `m`: M)(_ `n`: N)(_ `o`: O)(_ `p`: P)(_ `q`: Q)(_ `r`: R)(_ `s`: S)(_ `t`: T)(_ `u`: U)(_ `v`: V)(_ `w`: W)(_ `x`: X)(_ `y`: Y)(_ `z`: Z)(_ `aa`: AA)(_ `ab`: AB)(_ `ac`: AC)(_ `ad`: AD)(_ `ae`: AE)(_ `af`: AF)(_ `ag`: AG)(_ `ah`: AH)(_ `ai`: AI)(_ `aj`: AJ)(_ `ak`: AK)(_ `al`: AL)(_ `am`: AM)(_ `an`: AN)(_ `ao`: AO)(_ `ap`: AP)(_ `aq`: AQ)(_ `ar`: AR)(_ `as`: AS)(_ `at`: AT)(_ `au`: AU) -> AV {
+    return function(`a`, `b`, `c`, `d`, `e`, `f`, `g`, `h`, `i`, `j`, `k`, `l`, `m`, `n`, `o`, `p`, `q`, `r`, `s`, `t`, `u`, `v`, `w`, `x`, `y`, `z`, `aa`, `ab`, `ac`, `ad`, `ae`, `af`, `ag`, `ah`, `ai`, `aj`, `ak`, `al`, `am`, `an`, `ao`, `ap`, `aq`, `ar`, `as`, `at`, `au`)
+}
+
+public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AA, AB, AC, AD, AE, AF, AG, AH, AI, AJ, AK, AL, AM, AN, AO, AP, AQ, AR, AS, AT, AU, AV, AW>(function: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AA, AB, AC, AD, AE, AF, AG, AH, AI, AJ, AK, AL, AM, AN, AO, AP, AQ, AR, AS, AT, AU, AV) -> AW)(_ `a`: A)(_ `b`: B)(_ `c`: C)(_ `d`: D)(_ `e`: E)(_ `f`: F)(_ `g`: G)(_ `h`: H)(_ `i`: I)(_ `j`: J)(_ `k`: K)(_ `l`: L)(_ `m`: M)(_ `n`: N)(_ `o`: O)(_ `p`: P)(_ `q`: Q)(_ `r`: R)(_ `s`: S)(_ `t`: T)(_ `u`: U)(_ `v`: V)(_ `w`: W)(_ `x`: X)(_ `y`: Y)(_ `z`: Z)(_ `aa`: AA)(_ `ab`: AB)(_ `ac`: AC)(_ `ad`: AD)(_ `ae`: AE)(_ `af`: AF)(_ `ag`: AG)(_ `ah`: AH)(_ `ai`: AI)(_ `aj`: AJ)(_ `ak`: AK)(_ `al`: AL)(_ `am`: AM)(_ `an`: AN)(_ `ao`: AO)(_ `ap`: AP)(_ `aq`: AQ)(_ `ar`: AR)(_ `as`: AS)(_ `at`: AT)(_ `au`: AU)(_ `av`: AV) -> AW {
+    return function(`a`, `b`, `c`, `d`, `e`, `f`, `g`, `h`, `i`, `j`, `k`, `l`, `m`, `n`, `o`, `p`, `q`, `r`, `s`, `t`, `u`, `v`, `w`, `x`, `y`, `z`, `aa`, `ab`, `ac`, `ad`, `ae`, `af`, `ag`, `ah`, `ai`, `aj`, `ak`, `al`, `am`, `an`, `ao`, `ap`, `aq`, `ar`, `as`, `at`, `au`, `av`)
+}
+
+public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AA, AB, AC, AD, AE, AF, AG, AH, AI, AJ, AK, AL, AM, AN, AO, AP, AQ, AR, AS, AT, AU, AV, AW, AX>(function: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AA, AB, AC, AD, AE, AF, AG, AH, AI, AJ, AK, AL, AM, AN, AO, AP, AQ, AR, AS, AT, AU, AV, AW) -> AX)(_ `a`: A)(_ `b`: B)(_ `c`: C)(_ `d`: D)(_ `e`: E)(_ `f`: F)(_ `g`: G)(_ `h`: H)(_ `i`: I)(_ `j`: J)(_ `k`: K)(_ `l`: L)(_ `m`: M)(_ `n`: N)(_ `o`: O)(_ `p`: P)(_ `q`: Q)(_ `r`: R)(_ `s`: S)(_ `t`: T)(_ `u`: U)(_ `v`: V)(_ `w`: W)(_ `x`: X)(_ `y`: Y)(_ `z`: Z)(_ `aa`: AA)(_ `ab`: AB)(_ `ac`: AC)(_ `ad`: AD)(_ `ae`: AE)(_ `af`: AF)(_ `ag`: AG)(_ `ah`: AH)(_ `ai`: AI)(_ `aj`: AJ)(_ `ak`: AK)(_ `al`: AL)(_ `am`: AM)(_ `an`: AN)(_ `ao`: AO)(_ `ap`: AP)(_ `aq`: AQ)(_ `ar`: AR)(_ `as`: AS)(_ `at`: AT)(_ `au`: AU)(_ `av`: AV)(_ `aw`: AW) -> AX {
+    return function(`a`, `b`, `c`, `d`, `e`, `f`, `g`, `h`, `i`, `j`, `k`, `l`, `m`, `n`, `o`, `p`, `q`, `r`, `s`, `t`, `u`, `v`, `w`, `x`, `y`, `z`, `aa`, `ab`, `ac`, `ad`, `ae`, `af`, `ag`, `ah`, `ai`, `aj`, `ak`, `al`, `am`, `an`, `ao`, `ap`, `aq`, `ar`, `as`, `at`, `au`, `av`, `aw`)
+}
+
+public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AA, AB, AC, AD, AE, AF, AG, AH, AI, AJ, AK, AL, AM, AN, AO, AP, AQ, AR, AS, AT, AU, AV, AW, AX, AY>(function: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AA, AB, AC, AD, AE, AF, AG, AH, AI, AJ, AK, AL, AM, AN, AO, AP, AQ, AR, AS, AT, AU, AV, AW, AX) -> AY)(_ `a`: A)(_ `b`: B)(_ `c`: C)(_ `d`: D)(_ `e`: E)(_ `f`: F)(_ `g`: G)(_ `h`: H)(_ `i`: I)(_ `j`: J)(_ `k`: K)(_ `l`: L)(_ `m`: M)(_ `n`: N)(_ `o`: O)(_ `p`: P)(_ `q`: Q)(_ `r`: R)(_ `s`: S)(_ `t`: T)(_ `u`: U)(_ `v`: V)(_ `w`: W)(_ `x`: X)(_ `y`: Y)(_ `z`: Z)(_ `aa`: AA)(_ `ab`: AB)(_ `ac`: AC)(_ `ad`: AD)(_ `ae`: AE)(_ `af`: AF)(_ `ag`: AG)(_ `ah`: AH)(_ `ai`: AI)(_ `aj`: AJ)(_ `ak`: AK)(_ `al`: AL)(_ `am`: AM)(_ `an`: AN)(_ `ao`: AO)(_ `ap`: AP)(_ `aq`: AQ)(_ `ar`: AR)(_ `as`: AS)(_ `at`: AT)(_ `au`: AU)(_ `av`: AV)(_ `aw`: AW)(_ `ax`: AX) -> AY {
+    return function(`a`, `b`, `c`, `d`, `e`, `f`, `g`, `h`, `i`, `j`, `k`, `l`, `m`, `n`, `o`, `p`, `q`, `r`, `s`, `t`, `u`, `v`, `w`, `x`, `y`, `z`, `aa`, `ab`, `ac`, `ad`, `ae`, `af`, `ag`, `ah`, `ai`, `aj`, `ak`, `al`, `am`, `an`, `ao`, `ap`, `aq`, `ar`, `as`, `at`, `au`, `av`, `aw`, `ax`)
+}
+
+public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AA, AB, AC, AD, AE, AF, AG, AH, AI, AJ, AK, AL, AM, AN, AO, AP, AQ, AR, AS, AT, AU, AV, AW, AX, AY, AZ>(function: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AA, AB, AC, AD, AE, AF, AG, AH, AI, AJ, AK, AL, AM, AN, AO, AP, AQ, AR, AS, AT, AU, AV, AW, AX, AY) -> AZ)(_ `a`: A)(_ `b`: B)(_ `c`: C)(_ `d`: D)(_ `e`: E)(_ `f`: F)(_ `g`: G)(_ `h`: H)(_ `i`: I)(_ `j`: J)(_ `k`: K)(_ `l`: L)(_ `m`: M)(_ `n`: N)(_ `o`: O)(_ `p`: P)(_ `q`: Q)(_ `r`: R)(_ `s`: S)(_ `t`: T)(_ `u`: U)(_ `v`: V)(_ `w`: W)(_ `x`: X)(_ `y`: Y)(_ `z`: Z)(_ `aa`: AA)(_ `ab`: AB)(_ `ac`: AC)(_ `ad`: AD)(_ `ae`: AE)(_ `af`: AF)(_ `ag`: AG)(_ `ah`: AH)(_ `ai`: AI)(_ `aj`: AJ)(_ `ak`: AK)(_ `al`: AL)(_ `am`: AM)(_ `an`: AN)(_ `ao`: AO)(_ `ap`: AP)(_ `aq`: AQ)(_ `ar`: AR)(_ `as`: AS)(_ `at`: AT)(_ `au`: AU)(_ `av`: AV)(_ `aw`: AW)(_ `ax`: AX)(_ `ay`: AY) -> AZ {
+    return function(`a`, `b`, `c`, `d`, `e`, `f`, `g`, `h`, `i`, `j`, `k`, `l`, `m`, `n`, `o`, `p`, `q`, `r`, `s`, `t`, `u`, `v`, `w`, `x`, `y`, `z`, `aa`, `ab`, `ac`, `ad`, `ae`, `af`, `ag`, `ah`, `ai`, `aj`, `ak`, `al`, `am`, `an`, `ao`, `ap`, `aq`, `ar`, `as`, `at`, `au`, `av`, `aw`, `ax`, `ay`)
+}
+
+public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AA, AB, AC, AD, AE, AF, AG, AH, AI, AJ, AK, AL, AM, AN, AO, AP, AQ, AR, AS, AT, AU, AV, AW, AX, AY, AZ, BA>(function: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AA, AB, AC, AD, AE, AF, AG, AH, AI, AJ, AK, AL, AM, AN, AO, AP, AQ, AR, AS, AT, AU, AV, AW, AX, AY, AZ) -> BA)(_ `a`: A)(_ `b`: B)(_ `c`: C)(_ `d`: D)(_ `e`: E)(_ `f`: F)(_ `g`: G)(_ `h`: H)(_ `i`: I)(_ `j`: J)(_ `k`: K)(_ `l`: L)(_ `m`: M)(_ `n`: N)(_ `o`: O)(_ `p`: P)(_ `q`: Q)(_ `r`: R)(_ `s`: S)(_ `t`: T)(_ `u`: U)(_ `v`: V)(_ `w`: W)(_ `x`: X)(_ `y`: Y)(_ `z`: Z)(_ `aa`: AA)(_ `ab`: AB)(_ `ac`: AC)(_ `ad`: AD)(_ `ae`: AE)(_ `af`: AF)(_ `ag`: AG)(_ `ah`: AH)(_ `ai`: AI)(_ `aj`: AJ)(_ `ak`: AK)(_ `al`: AL)(_ `am`: AM)(_ `an`: AN)(_ `ao`: AO)(_ `ap`: AP)(_ `aq`: AQ)(_ `ar`: AR)(_ `as`: AS)(_ `at`: AT)(_ `au`: AU)(_ `av`: AV)(_ `aw`: AW)(_ `ax`: AX)(_ `ay`: AY)(_ `az`: AZ) -> BA {
+    return function(`a`, `b`, `c`, `d`, `e`, `f`, `g`, `h`, `i`, `j`, `k`, `l`, `m`, `n`, `o`, `p`, `q`, `r`, `s`, `t`, `u`, `v`, `w`, `x`, `y`, `z`, `aa`, `ab`, `ac`, `ad`, `ae`, `af`, `ag`, `ah`, `ai`, `aj`, `ak`, `al`, `am`, `an`, `ao`, `ap`, `aq`, `ar`, `as`, `at`, `au`, `av`, `aw`, `ax`, `ay`, `az`)
+}
+
+public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AA, AB, AC, AD, AE, AF, AG, AH, AI, AJ, AK, AL, AM, AN, AO, AP, AQ, AR, AS, AT, AU, AV, AW, AX, AY, AZ, BA, BB>(function: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AA, AB, AC, AD, AE, AF, AG, AH, AI, AJ, AK, AL, AM, AN, AO, AP, AQ, AR, AS, AT, AU, AV, AW, AX, AY, AZ, BA) -> BB)(_ `a`: A)(_ `b`: B)(_ `c`: C)(_ `d`: D)(_ `e`: E)(_ `f`: F)(_ `g`: G)(_ `h`: H)(_ `i`: I)(_ `j`: J)(_ `k`: K)(_ `l`: L)(_ `m`: M)(_ `n`: N)(_ `o`: O)(_ `p`: P)(_ `q`: Q)(_ `r`: R)(_ `s`: S)(_ `t`: T)(_ `u`: U)(_ `v`: V)(_ `w`: W)(_ `x`: X)(_ `y`: Y)(_ `z`: Z)(_ `aa`: AA)(_ `ab`: AB)(_ `ac`: AC)(_ `ad`: AD)(_ `ae`: AE)(_ `af`: AF)(_ `ag`: AG)(_ `ah`: AH)(_ `ai`: AI)(_ `aj`: AJ)(_ `ak`: AK)(_ `al`: AL)(_ `am`: AM)(_ `an`: AN)(_ `ao`: AO)(_ `ap`: AP)(_ `aq`: AQ)(_ `ar`: AR)(_ `as`: AS)(_ `at`: AT)(_ `au`: AU)(_ `av`: AV)(_ `aw`: AW)(_ `ax`: AX)(_ `ay`: AY)(_ `az`: AZ)(_ `ba`: BA) -> BB {
+    return function(`a`, `b`, `c`, `d`, `e`, `f`, `g`, `h`, `i`, `j`, `k`, `l`, `m`, `n`, `o`, `p`, `q`, `r`, `s`, `t`, `u`, `v`, `w`, `x`, `y`, `z`, `aa`, `ab`, `ac`, `ad`, `ae`, `af`, `ag`, `ah`, `ai`, `aj`, `ak`, `al`, `am`, `an`, `ao`, `ap`, `aq`, `ar`, `as`, `at`, `au`, `av`, `aw`, `ax`, `ay`, `az`, `ba`)
+}
+
+public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AA, AB, AC, AD, AE, AF, AG, AH, AI, AJ, AK, AL, AM, AN, AO, AP, AQ, AR, AS, AT, AU, AV, AW, AX, AY, AZ, BA, BB, BC>(function: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AA, AB, AC, AD, AE, AF, AG, AH, AI, AJ, AK, AL, AM, AN, AO, AP, AQ, AR, AS, AT, AU, AV, AW, AX, AY, AZ, BA, BB) -> BC)(_ `a`: A)(_ `b`: B)(_ `c`: C)(_ `d`: D)(_ `e`: E)(_ `f`: F)(_ `g`: G)(_ `h`: H)(_ `i`: I)(_ `j`: J)(_ `k`: K)(_ `l`: L)(_ `m`: M)(_ `n`: N)(_ `o`: O)(_ `p`: P)(_ `q`: Q)(_ `r`: R)(_ `s`: S)(_ `t`: T)(_ `u`: U)(_ `v`: V)(_ `w`: W)(_ `x`: X)(_ `y`: Y)(_ `z`: Z)(_ `aa`: AA)(_ `ab`: AB)(_ `ac`: AC)(_ `ad`: AD)(_ `ae`: AE)(_ `af`: AF)(_ `ag`: AG)(_ `ah`: AH)(_ `ai`: AI)(_ `aj`: AJ)(_ `ak`: AK)(_ `al`: AL)(_ `am`: AM)(_ `an`: AN)(_ `ao`: AO)(_ `ap`: AP)(_ `aq`: AQ)(_ `ar`: AR)(_ `as`: AS)(_ `at`: AT)(_ `au`: AU)(_ `av`: AV)(_ `aw`: AW)(_ `ax`: AX)(_ `ay`: AY)(_ `az`: AZ)(_ `ba`: BA)(_ `bb`: BB) -> BC {
+    return function(`a`, `b`, `c`, `d`, `e`, `f`, `g`, `h`, `i`, `j`, `k`, `l`, `m`, `n`, `o`, `p`, `q`, `r`, `s`, `t`, `u`, `v`, `w`, `x`, `y`, `z`, `aa`, `ab`, `ac`, `ad`, `ae`, `af`, `ag`, `ah`, `ai`, `aj`, `ak`, `al`, `am`, `an`, `ao`, `ap`, `aq`, `ar`, `as`, `at`, `au`, `av`, `aw`, `ax`, `ay`, `az`, `ba`, `bb`)
+}
+
+public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AA, AB, AC, AD, AE, AF, AG, AH, AI, AJ, AK, AL, AM, AN, AO, AP, AQ, AR, AS, AT, AU, AV, AW, AX, AY, AZ, BA, BB, BC, BD>(function: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AA, AB, AC, AD, AE, AF, AG, AH, AI, AJ, AK, AL, AM, AN, AO, AP, AQ, AR, AS, AT, AU, AV, AW, AX, AY, AZ, BA, BB, BC) -> BD)(_ `a`: A)(_ `b`: B)(_ `c`: C)(_ `d`: D)(_ `e`: E)(_ `f`: F)(_ `g`: G)(_ `h`: H)(_ `i`: I)(_ `j`: J)(_ `k`: K)(_ `l`: L)(_ `m`: M)(_ `n`: N)(_ `o`: O)(_ `p`: P)(_ `q`: Q)(_ `r`: R)(_ `s`: S)(_ `t`: T)(_ `u`: U)(_ `v`: V)(_ `w`: W)(_ `x`: X)(_ `y`: Y)(_ `z`: Z)(_ `aa`: AA)(_ `ab`: AB)(_ `ac`: AC)(_ `ad`: AD)(_ `ae`: AE)(_ `af`: AF)(_ `ag`: AG)(_ `ah`: AH)(_ `ai`: AI)(_ `aj`: AJ)(_ `ak`: AK)(_ `al`: AL)(_ `am`: AM)(_ `an`: AN)(_ `ao`: AO)(_ `ap`: AP)(_ `aq`: AQ)(_ `ar`: AR)(_ `as`: AS)(_ `at`: AT)(_ `au`: AU)(_ `av`: AV)(_ `aw`: AW)(_ `ax`: AX)(_ `ay`: AY)(_ `az`: AZ)(_ `ba`: BA)(_ `bb`: BB)(_ `bc`: BC) -> BD {
+    return function(`a`, `b`, `c`, `d`, `e`, `f`, `g`, `h`, `i`, `j`, `k`, `l`, `m`, `n`, `o`, `p`, `q`, `r`, `s`, `t`, `u`, `v`, `w`, `x`, `y`, `z`, `aa`, `ab`, `ac`, `ad`, `ae`, `af`, `ag`, `ah`, `ai`, `aj`, `ak`, `al`, `am`, `an`, `ao`, `ap`, `aq`, `ar`, `as`, `at`, `au`, `av`, `aw`, `ax`, `ay`, `az`, `ba`, `bb`, `bc`)
+}
+
+public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AA, AB, AC, AD, AE, AF, AG, AH, AI, AJ, AK, AL, AM, AN, AO, AP, AQ, AR, AS, AT, AU, AV, AW, AX, AY, AZ, BA, BB, BC, BD, BE>(function: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AA, AB, AC, AD, AE, AF, AG, AH, AI, AJ, AK, AL, AM, AN, AO, AP, AQ, AR, AS, AT, AU, AV, AW, AX, AY, AZ, BA, BB, BC, BD) -> BE)(_ `a`: A)(_ `b`: B)(_ `c`: C)(_ `d`: D)(_ `e`: E)(_ `f`: F)(_ `g`: G)(_ `h`: H)(_ `i`: I)(_ `j`: J)(_ `k`: K)(_ `l`: L)(_ `m`: M)(_ `n`: N)(_ `o`: O)(_ `p`: P)(_ `q`: Q)(_ `r`: R)(_ `s`: S)(_ `t`: T)(_ `u`: U)(_ `v`: V)(_ `w`: W)(_ `x`: X)(_ `y`: Y)(_ `z`: Z)(_ `aa`: AA)(_ `ab`: AB)(_ `ac`: AC)(_ `ad`: AD)(_ `ae`: AE)(_ `af`: AF)(_ `ag`: AG)(_ `ah`: AH)(_ `ai`: AI)(_ `aj`: AJ)(_ `ak`: AK)(_ `al`: AL)(_ `am`: AM)(_ `an`: AN)(_ `ao`: AO)(_ `ap`: AP)(_ `aq`: AQ)(_ `ar`: AR)(_ `as`: AS)(_ `at`: AT)(_ `au`: AU)(_ `av`: AV)(_ `aw`: AW)(_ `ax`: AX)(_ `ay`: AY)(_ `az`: AZ)(_ `ba`: BA)(_ `bb`: BB)(_ `bc`: BC)(_ `bd`: BD) -> BE {
+    return function(`a`, `b`, `c`, `d`, `e`, `f`, `g`, `h`, `i`, `j`, `k`, `l`, `m`, `n`, `o`, `p`, `q`, `r`, `s`, `t`, `u`, `v`, `w`, `x`, `y`, `z`, `aa`, `ab`, `ac`, `ad`, `ae`, `af`, `ag`, `ah`, `ai`, `aj`, `ak`, `al`, `am`, `an`, `ao`, `ap`, `aq`, `ar`, `as`, `at`, `au`, `av`, `aw`, `ax`, `ay`, `az`, `ba`, `bb`, `bc`, `bd`)
+}
+
+public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AA, AB, AC, AD, AE, AF, AG, AH, AI, AJ, AK, AL, AM, AN, AO, AP, AQ, AR, AS, AT, AU, AV, AW, AX, AY, AZ, BA, BB, BC, BD, BE, BF>(function: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AA, AB, AC, AD, AE, AF, AG, AH, AI, AJ, AK, AL, AM, AN, AO, AP, AQ, AR, AS, AT, AU, AV, AW, AX, AY, AZ, BA, BB, BC, BD, BE) -> BF)(_ `a`: A)(_ `b`: B)(_ `c`: C)(_ `d`: D)(_ `e`: E)(_ `f`: F)(_ `g`: G)(_ `h`: H)(_ `i`: I)(_ `j`: J)(_ `k`: K)(_ `l`: L)(_ `m`: M)(_ `n`: N)(_ `o`: O)(_ `p`: P)(_ `q`: Q)(_ `r`: R)(_ `s`: S)(_ `t`: T)(_ `u`: U)(_ `v`: V)(_ `w`: W)(_ `x`: X)(_ `y`: Y)(_ `z`: Z)(_ `aa`: AA)(_ `ab`: AB)(_ `ac`: AC)(_ `ad`: AD)(_ `ae`: AE)(_ `af`: AF)(_ `ag`: AG)(_ `ah`: AH)(_ `ai`: AI)(_ `aj`: AJ)(_ `ak`: AK)(_ `al`: AL)(_ `am`: AM)(_ `an`: AN)(_ `ao`: AO)(_ `ap`: AP)(_ `aq`: AQ)(_ `ar`: AR)(_ `as`: AS)(_ `at`: AT)(_ `au`: AU)(_ `av`: AV)(_ `aw`: AW)(_ `ax`: AX)(_ `ay`: AY)(_ `az`: AZ)(_ `ba`: BA)(_ `bb`: BB)(_ `bc`: BC)(_ `bd`: BD)(_ `be`: BE) -> BF {
+    return function(`a`, `b`, `c`, `d`, `e`, `f`, `g`, `h`, `i`, `j`, `k`, `l`, `m`, `n`, `o`, `p`, `q`, `r`, `s`, `t`, `u`, `v`, `w`, `x`, `y`, `z`, `aa`, `ab`, `ac`, `ad`, `ae`, `af`, `ag`, `ah`, `ai`, `aj`, `ak`, `al`, `am`, `an`, `ao`, `ap`, `aq`, `ar`, `as`, `at`, `au`, `av`, `aw`, `ax`, `ay`, `az`, `ba`, `bb`, `bc`, `bd`, `be`)
+}
+
+public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AA, AB, AC, AD, AE, AF, AG, AH, AI, AJ, AK, AL, AM, AN, AO, AP, AQ, AR, AS, AT, AU, AV, AW, AX, AY, AZ, BA, BB, BC, BD, BE, BF, BG>(function: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AA, AB, AC, AD, AE, AF, AG, AH, AI, AJ, AK, AL, AM, AN, AO, AP, AQ, AR, AS, AT, AU, AV, AW, AX, AY, AZ, BA, BB, BC, BD, BE, BF) -> BG)(_ `a`: A)(_ `b`: B)(_ `c`: C)(_ `d`: D)(_ `e`: E)(_ `f`: F)(_ `g`: G)(_ `h`: H)(_ `i`: I)(_ `j`: J)(_ `k`: K)(_ `l`: L)(_ `m`: M)(_ `n`: N)(_ `o`: O)(_ `p`: P)(_ `q`: Q)(_ `r`: R)(_ `s`: S)(_ `t`: T)(_ `u`: U)(_ `v`: V)(_ `w`: W)(_ `x`: X)(_ `y`: Y)(_ `z`: Z)(_ `aa`: AA)(_ `ab`: AB)(_ `ac`: AC)(_ `ad`: AD)(_ `ae`: AE)(_ `af`: AF)(_ `ag`: AG)(_ `ah`: AH)(_ `ai`: AI)(_ `aj`: AJ)(_ `ak`: AK)(_ `al`: AL)(_ `am`: AM)(_ `an`: AN)(_ `ao`: AO)(_ `ap`: AP)(_ `aq`: AQ)(_ `ar`: AR)(_ `as`: AS)(_ `at`: AT)(_ `au`: AU)(_ `av`: AV)(_ `aw`: AW)(_ `ax`: AX)(_ `ay`: AY)(_ `az`: AZ)(_ `ba`: BA)(_ `bb`: BB)(_ `bc`: BC)(_ `bd`: BD)(_ `be`: BE)(_ `bf`: BF) -> BG {
+    return function(`a`, `b`, `c`, `d`, `e`, `f`, `g`, `h`, `i`, `j`, `k`, `l`, `m`, `n`, `o`, `p`, `q`, `r`, `s`, `t`, `u`, `v`, `w`, `x`, `y`, `z`, `aa`, `ab`, `ac`, `ad`, `ae`, `af`, `ag`, `ah`, `ai`, `aj`, `ak`, `al`, `am`, `an`, `ao`, `ap`, `aq`, `ar`, `as`, `at`, `au`, `av`, `aw`, `ax`, `ay`, `az`, `ba`, `bb`, `bc`, `bd`, `be`, `bf`)
+}
+
+public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AA, AB, AC, AD, AE, AF, AG, AH, AI, AJ, AK, AL, AM, AN, AO, AP, AQ, AR, AS, AT, AU, AV, AW, AX, AY, AZ, BA, BB, BC, BD, BE, BF, BG, BH>(function: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AA, AB, AC, AD, AE, AF, AG, AH, AI, AJ, AK, AL, AM, AN, AO, AP, AQ, AR, AS, AT, AU, AV, AW, AX, AY, AZ, BA, BB, BC, BD, BE, BF, BG) -> BH)(_ `a`: A)(_ `b`: B)(_ `c`: C)(_ `d`: D)(_ `e`: E)(_ `f`: F)(_ `g`: G)(_ `h`: H)(_ `i`: I)(_ `j`: J)(_ `k`: K)(_ `l`: L)(_ `m`: M)(_ `n`: N)(_ `o`: O)(_ `p`: P)(_ `q`: Q)(_ `r`: R)(_ `s`: S)(_ `t`: T)(_ `u`: U)(_ `v`: V)(_ `w`: W)(_ `x`: X)(_ `y`: Y)(_ `z`: Z)(_ `aa`: AA)(_ `ab`: AB)(_ `ac`: AC)(_ `ad`: AD)(_ `ae`: AE)(_ `af`: AF)(_ `ag`: AG)(_ `ah`: AH)(_ `ai`: AI)(_ `aj`: AJ)(_ `ak`: AK)(_ `al`: AL)(_ `am`: AM)(_ `an`: AN)(_ `ao`: AO)(_ `ap`: AP)(_ `aq`: AQ)(_ `ar`: AR)(_ `as`: AS)(_ `at`: AT)(_ `au`: AU)(_ `av`: AV)(_ `aw`: AW)(_ `ax`: AX)(_ `ay`: AY)(_ `az`: AZ)(_ `ba`: BA)(_ `bb`: BB)(_ `bc`: BC)(_ `bd`: BD)(_ `be`: BE)(_ `bf`: BF)(_ `bg`: BG) -> BH {
+    return function(`a`, `b`, `c`, `d`, `e`, `f`, `g`, `h`, `i`, `j`, `k`, `l`, `m`, `n`, `o`, `p`, `q`, `r`, `s`, `t`, `u`, `v`, `w`, `x`, `y`, `z`, `aa`, `ab`, `ac`, `ad`, `ae`, `af`, `ag`, `ah`, `ai`, `aj`, `ak`, `al`, `am`, `an`, `ao`, `ap`, `aq`, `ar`, `as`, `at`, `au`, `av`, `aw`, `ax`, `ay`, `az`, `ba`, `bb`, `bc`, `bd`, `be`, `bf`, `bg`)
+}
+
+public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AA, AB, AC, AD, AE, AF, AG, AH, AI, AJ, AK, AL, AM, AN, AO, AP, AQ, AR, AS, AT, AU, AV, AW, AX, AY, AZ, BA, BB, BC, BD, BE, BF, BG, BH, BI>(function: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AA, AB, AC, AD, AE, AF, AG, AH, AI, AJ, AK, AL, AM, AN, AO, AP, AQ, AR, AS, AT, AU, AV, AW, AX, AY, AZ, BA, BB, BC, BD, BE, BF, BG, BH) -> BI)(_ `a`: A)(_ `b`: B)(_ `c`: C)(_ `d`: D)(_ `e`: E)(_ `f`: F)(_ `g`: G)(_ `h`: H)(_ `i`: I)(_ `j`: J)(_ `k`: K)(_ `l`: L)(_ `m`: M)(_ `n`: N)(_ `o`: O)(_ `p`: P)(_ `q`: Q)(_ `r`: R)(_ `s`: S)(_ `t`: T)(_ `u`: U)(_ `v`: V)(_ `w`: W)(_ `x`: X)(_ `y`: Y)(_ `z`: Z)(_ `aa`: AA)(_ `ab`: AB)(_ `ac`: AC)(_ `ad`: AD)(_ `ae`: AE)(_ `af`: AF)(_ `ag`: AG)(_ `ah`: AH)(_ `ai`: AI)(_ `aj`: AJ)(_ `ak`: AK)(_ `al`: AL)(_ `am`: AM)(_ `an`: AN)(_ `ao`: AO)(_ `ap`: AP)(_ `aq`: AQ)(_ `ar`: AR)(_ `as`: AS)(_ `at`: AT)(_ `au`: AU)(_ `av`: AV)(_ `aw`: AW)(_ `ax`: AX)(_ `ay`: AY)(_ `az`: AZ)(_ `ba`: BA)(_ `bb`: BB)(_ `bc`: BC)(_ `bd`: BD)(_ `be`: BE)(_ `bf`: BF)(_ `bg`: BG)(_ `bh`: BH) -> BI {
+    return function(`a`, `b`, `c`, `d`, `e`, `f`, `g`, `h`, `i`, `j`, `k`, `l`, `m`, `n`, `o`, `p`, `q`, `r`, `s`, `t`, `u`, `v`, `w`, `x`, `y`, `z`, `aa`, `ab`, `ac`, `ad`, `ae`, `af`, `ag`, `ah`, `ai`, `aj`, `ak`, `al`, `am`, `an`, `ao`, `ap`, `aq`, `ar`, `as`, `at`, `au`, `av`, `aw`, `ax`, `ay`, `az`, `ba`, `bb`, `bc`, `bd`, `be`, `bf`, `bg`, `bh`)
+}
+
+public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AA, AB, AC, AD, AE, AF, AG, AH, AI, AJ, AK, AL, AM, AN, AO, AP, AQ, AR, AS, AT, AU, AV, AW, AX, AY, AZ, BA, BB, BC, BD, BE, BF, BG, BH, BI, BJ>(function: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AA, AB, AC, AD, AE, AF, AG, AH, AI, AJ, AK, AL, AM, AN, AO, AP, AQ, AR, AS, AT, AU, AV, AW, AX, AY, AZ, BA, BB, BC, BD, BE, BF, BG, BH, BI) -> BJ)(_ `a`: A)(_ `b`: B)(_ `c`: C)(_ `d`: D)(_ `e`: E)(_ `f`: F)(_ `g`: G)(_ `h`: H)(_ `i`: I)(_ `j`: J)(_ `k`: K)(_ `l`: L)(_ `m`: M)(_ `n`: N)(_ `o`: O)(_ `p`: P)(_ `q`: Q)(_ `r`: R)(_ `s`: S)(_ `t`: T)(_ `u`: U)(_ `v`: V)(_ `w`: W)(_ `x`: X)(_ `y`: Y)(_ `z`: Z)(_ `aa`: AA)(_ `ab`: AB)(_ `ac`: AC)(_ `ad`: AD)(_ `ae`: AE)(_ `af`: AF)(_ `ag`: AG)(_ `ah`: AH)(_ `ai`: AI)(_ `aj`: AJ)(_ `ak`: AK)(_ `al`: AL)(_ `am`: AM)(_ `an`: AN)(_ `ao`: AO)(_ `ap`: AP)(_ `aq`: AQ)(_ `ar`: AR)(_ `as`: AS)(_ `at`: AT)(_ `au`: AU)(_ `av`: AV)(_ `aw`: AW)(_ `ax`: AX)(_ `ay`: AY)(_ `az`: AZ)(_ `ba`: BA)(_ `bb`: BB)(_ `bc`: BC)(_ `bd`: BD)(_ `be`: BE)(_ `bf`: BF)(_ `bg`: BG)(_ `bh`: BH)(_ `bi`: BI) -> BJ {
+    return function(`a`, `b`, `c`, `d`, `e`, `f`, `g`, `h`, `i`, `j`, `k`, `l`, `m`, `n`, `o`, `p`, `q`, `r`, `s`, `t`, `u`, `v`, `w`, `x`, `y`, `z`, `aa`, `ab`, `ac`, `ad`, `ae`, `af`, `ag`, `ah`, `ai`, `aj`, `ak`, `al`, `am`, `an`, `ao`, `ap`, `aq`, `ar`, `as`, `at`, `au`, `av`, `aw`, `ax`, `ay`, `az`, `ba`, `bb`, `bc`, `bd`, `be`, `bf`, `bg`, `bh`, `bi`)
+}
+
+public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AA, AB, AC, AD, AE, AF, AG, AH, AI, AJ, AK, AL, AM, AN, AO, AP, AQ, AR, AS, AT, AU, AV, AW, AX, AY, AZ, BA, BB, BC, BD, BE, BF, BG, BH, BI, BJ, BK>(function: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AA, AB, AC, AD, AE, AF, AG, AH, AI, AJ, AK, AL, AM, AN, AO, AP, AQ, AR, AS, AT, AU, AV, AW, AX, AY, AZ, BA, BB, BC, BD, BE, BF, BG, BH, BI, BJ) -> BK)(_ `a`: A)(_ `b`: B)(_ `c`: C)(_ `d`: D)(_ `e`: E)(_ `f`: F)(_ `g`: G)(_ `h`: H)(_ `i`: I)(_ `j`: J)(_ `k`: K)(_ `l`: L)(_ `m`: M)(_ `n`: N)(_ `o`: O)(_ `p`: P)(_ `q`: Q)(_ `r`: R)(_ `s`: S)(_ `t`: T)(_ `u`: U)(_ `v`: V)(_ `w`: W)(_ `x`: X)(_ `y`: Y)(_ `z`: Z)(_ `aa`: AA)(_ `ab`: AB)(_ `ac`: AC)(_ `ad`: AD)(_ `ae`: AE)(_ `af`: AF)(_ `ag`: AG)(_ `ah`: AH)(_ `ai`: AI)(_ `aj`: AJ)(_ `ak`: AK)(_ `al`: AL)(_ `am`: AM)(_ `an`: AN)(_ `ao`: AO)(_ `ap`: AP)(_ `aq`: AQ)(_ `ar`: AR)(_ `as`: AS)(_ `at`: AT)(_ `au`: AU)(_ `av`: AV)(_ `aw`: AW)(_ `ax`: AX)(_ `ay`: AY)(_ `az`: AZ)(_ `ba`: BA)(_ `bb`: BB)(_ `bc`: BC)(_ `bd`: BD)(_ `be`: BE)(_ `bf`: BF)(_ `bg`: BG)(_ `bh`: BH)(_ `bi`: BI)(_ `bj`: BJ) -> BK {
+    return function(`a`, `b`, `c`, `d`, `e`, `f`, `g`, `h`, `i`, `j`, `k`, `l`, `m`, `n`, `o`, `p`, `q`, `r`, `s`, `t`, `u`, `v`, `w`, `x`, `y`, `z`, `aa`, `ab`, `ac`, `ad`, `ae`, `af`, `ag`, `ah`, `ai`, `aj`, `ak`, `al`, `am`, `an`, `ao`, `ap`, `aq`, `ar`, `as`, `at`, `au`, `av`, `aw`, `ax`, `ay`, `az`, `ba`, `bb`, `bc`, `bd`, `be`, `bf`, `bg`, `bh`, `bi`, `bj`)
+}

--- a/generator.swift
+++ b/generator.swift
@@ -1,0 +1,55 @@
+// Generates a Swift file with implementation of function currying for a ridicolously high number of arguments
+
+import Foundation
+
+let generics = ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z", "AA"]
+
+// Set the threshold of arguments number after which the compiler cannot keep up
+let threshold: Int = (Process.arguments.count >= 2) ? Int(Process.arguments[1])! : 16
+
+let compileTimeIssueComment = "Compile time become exponential past this point"
+
+let outputPath = "Source/Curry.swift"
+
+let curryGenerator: (arguments: Int) -> String = { arguments in
+  let types = ", ".join(generics[0..<arguments])
+  let functionTypes = ", ".join(generics[0..<arguments - 1])
+  let returnType = " -> ".join(generics[0..<arguments])
+  let ins = " in { ".join(generics[0..<arguments - 1]).lowercaseString
+  let functionArguments = functionTypes.lowercaseString
+  let trailingBrackets = " ".join((0..<arguments - 2).map { Int -> String in "}" })
+
+  var curry = "public func curry<\(types)>(function: (\(functionTypes)) -> \(generics[arguments - 1])) -> \(returnType) {"
+  curry += "\n    return { \(ins) in function(\(functionArguments)) \(trailingBrackets) }"
+  curry += "\n}"
+
+  return curry
+}
+
+print("Generating 💬")
+
+// We start with 3 because that correspond to (A, B) -> C that then becomes A -> B -> C
+// If we were using 2 it would be (A) -> B that then becomes A -> B, which is the same
+let start = 3
+let curries = (start...generics.count).map { curryGenerator(arguments: $0) }
+let usableCurries = curries[0...threshold - start]
+let unusableCurries = curries[threshold - start + 1..<curries.count]
+
+let newLine = "\n\n"
+let comment = "//"
+var output = newLine.join(usableCurries)
+output += newLine + comment + " " + compileTimeIssueComment + newLine
+// Here we split each unusable curry method into its lines, add a comment at the start of each, then reassemble into a single string
+output += newLine.join(unusableCurries.map { "\n".join(split($0.characters) { $0 == "\n" }.map { String.init($0) }.map { comment + $0 }) })
+output += "\n"
+
+let currentPath = NSFileManager.defaultManager().currentDirectoryPath
+let currySwiftPath = currentPath.stringByAppendingPathComponent(outputPath)
+
+do {
+  try output.writeToFile(currySwiftPath, atomically: true, encoding: NSUTF8StringEncoding)
+} catch _ {
+  print("An error occurred while saving the generated functions to \"\(output)\"")
+}
+
+print("Done, curry functions files written at \(outputPath) 👍")

--- a/generator.swift
+++ b/generator.swift
@@ -2,25 +2,26 @@
 
 import Foundation
 
-let generics = ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z", "AA"]
+let generics = ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z"]
 
-// Set the threshold of arguments number after which the compiler cannot keep up
-let threshold: Int = (Process.arguments.count >= 2) ? Int(Process.arguments[1])! : 16
-
-let compileTimeIssueComment = "Compile time become exponential past this point"
-
-let outputPath = "Source/Curry.swift"
+let genericsGenerator: Int -> String = { x in
+  let max = generics.count
+  switch x {
+  case _ where x < max: return generics[x % max]
+  default: return generics[x / max - 1] + generics[x % max]
+  }
+}
 
 let curryGenerator: (arguments: Int) -> String = { arguments in
-  let types = ", ".join(generics[0..<arguments])
-  let functionTypes = ", ".join(generics[0..<arguments - 1])
-  let returnType = " -> ".join(generics[0..<arguments])
-  let ins = " in { ".join(generics[0..<arguments - 1]).lowercaseString
-  let functionArguments = functionTypes.lowercaseString
-  let trailingBrackets = " ".join((0..<arguments - 2).map { Int -> String in "}" })
+  let totalGenerics = (0..<arguments).map(genericsGenerator)
+  let types = totalGenerics[0..<arguments].joinWithSeparator(", ")
+  let functionTypes = totalGenerics[0..<arguments - 1].joinWithSeparator(", ")
+  let parameters = totalGenerics[0..<arguments - 1].map { "(_ `\($0.lowercaseString)`: \($0))" }.joinWithSeparator("")
+  let returnType = totalGenerics[arguments - 1]
+  let functionArguments = totalGenerics[0..<arguments - 1].map { "`\($0.lowercaseString)`" }.joinWithSeparator(", ")
 
-  var curry = "public func curry<\(types)>(function: (\(functionTypes)) -> \(generics[arguments - 1])) -> \(returnType) {"
-  curry += "\n    return { \(ins) in function(\(functionArguments)) \(trailingBrackets) }"
+  var curry = "public func curry<\(types)>(function: (\(functionTypes)) -> \(returnType))\(parameters) -> \(returnType) {"
+  curry += "\n    return function(\(functionArguments))"
   curry += "\n}"
 
   return curry
@@ -28,28 +29,20 @@ let curryGenerator: (arguments: Int) -> String = { arguments in
 
 print("Generating 💬")
 
-// We start with 3 because that correspond to (A, B) -> C that then becomes A -> B -> C
-// If we were using 2 it would be (A) -> B that then becomes A -> B, which is the same
-let start = 3
-let curries = (start...generics.count).map { curryGenerator(arguments: $0) }
-let usableCurries = curries[0...threshold - start]
-let unusableCurries = curries[threshold - start + 1..<curries.count]
+let start = 2
+let knownLimitOfGenericParameters = 64
+let curries = (start..<knownLimitOfGenericParameters).map { curryGenerator(arguments: $0) }
 
-let newLine = "\n\n"
-let comment = "//"
-var output = newLine.join(usableCurries)
-output += newLine + comment + " " + compileTimeIssueComment + newLine
-// Here we split each unusable curry method into its lines, add a comment at the start of each, then reassemble into a single string
-output += newLine.join(unusableCurries.map { "\n".join(split($0.characters) { $0 == "\n" }.map { String.init($0) }.map { comment + $0 }) })
-output += "\n"
+let output = curries.joinWithSeparator("\n\n") + "\n"
 
-let currentPath = NSFileManager.defaultManager().currentDirectoryPath
-let currySwiftPath = currentPath.stringByAppendingPathComponent(outputPath)
+let outputPath = "Source/Curry.swift"
+let currentPath = NSURL(fileURLWithPath: NSFileManager.defaultManager().currentDirectoryPath)
+let currySwiftPath = currentPath.URLByAppendingPathComponent(outputPath)
 
 do {
-  try output.writeToFile(currySwiftPath, atomically: true, encoding: NSUTF8StringEncoding)
-} catch _ {
-  print("An error occurred while saving the generated functions to \"\(output)\"")
+  try output.writeToURL(currySwiftPath, atomically: true, encoding: NSUTF8StringEncoding)
+} catch let e as NSError {
+  print("An error occurred while saving the generated functions. Error: \(e)")
 }
 
 print("Done, curry functions files written at \(outputPath) 👍")


### PR DESCRIPTION
The generator has been updated to Swift 2.0 and also has been rewritten
to generate endless `curry` functions by concatenating the alphabet as
it goes, ie ...Y, Z, AA, AB, etc.

The biggest change is that it was rewritten to use the other curry
syntax, `(a: A)(b: B)` instead of `A -> B`. This is easier on the
compiler and we can far extend the limit. It also compiles instantly.

The limit of generic parameters was found to be 64, which I think is
interestingly a power of 2. I wonder if that number is either hard
coded in Swift or if Swift internally uses a small amount of bits for
this. ANYWAYS, I think if you need more than a 64 parameter `curry`
function then you're probably doing it wrong.
