### PR TITLE
Full bitcode support

### DIFF
--- a/Curry.xcodeproj/project.pbxproj
+++ b/Curry.xcodeproj/project.pbxproj
@@ -401,6 +401,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				BITCODE_GENERATION_MODE = marker;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -449,6 +450,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				BITCODE_GENERATION_MODE = bitcode;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -585,6 +587,7 @@
 				80E0590D1BA9FA7F0077CBA7 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		F88630501B4EF96200F53969 /* Build configuration list for PBXProject "Curry" */ = {
 			isa = XCConfigurationList;


### PR DESCRIPTION
Added full bitcode support as described in Carthage/Carthage#535.

The user-defined setting added allows the framework to be built with bitcode, otherwise the linker fails with a nasty error message:

```
ld: bitcode bundle could not be generated because '/.../yourapp-ios/Carthage/Build/iOS/Curry.framework/Curry' was built without full bitcode. All frameworks and dylibs for bitcode must be generated from Xcode Archive or Install build for architecture arm64
```
